### PR TITLE
feat: expand to all supported legal document types (PL-6)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from database import init_db
 from routers.auth import router as auth_router
 from routers.catalog import router as catalog_router
 from routers.chat import router as chat_router
+from routers.doc_chat import router as doc_chat_router
 from routers.generate import router as generate_router
 
 load_dotenv()
@@ -37,6 +38,7 @@ app.add_middleware(
 app.include_router(auth_router)
 app.include_router(catalog_router)
 app.include_router(chat_router)
+app.include_router(doc_chat_router)
 app.include_router(generate_router)
 
 # Serve the static Next.js export when available (Docker production)

--- a/backend/models/doc_chat.py
+++ b/backend/models/doc_chat.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+
+from models.chat import ChatMessage
+
+
+class DocChatRequest(BaseModel):
+    doc_type: str  # slug, e.g. "csa"
+    messages: list[ChatMessage]
+    current_fields: dict[str, str | None] = {}
+
+
+class DocChatResponse(BaseModel):
+    reply: str
+    fields: dict[str, str | None] = {}
+    complete: bool = False
+
+
+class DocGenerateRequest(BaseModel):
+    doc_type: str
+    fields: dict[str, str | None]
+    title: str = ""

--- a/backend/routers/doc_chat.py
+++ b/backend/routers/doc_chat.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import PlainTextResponse
+
+from models.doc_chat import DocChatRequest, DocChatResponse, DocGenerateRequest
+from services.doc_chat import call_doc_chat, get_template
+from services.doc_renderer import render_generic_doc
+
+router = APIRouter(prefix="/api")
+
+
+@router.post("/doc-chat", response_model=DocChatResponse)
+def doc_chat(req: DocChatRequest) -> DocChatResponse:
+    try:
+        return call_doc_chat(req.doc_type, req.messages, req.current_fields)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Chat error: {str(e)}")
+
+
+@router.get("/doc-templates/{slug}", response_class=PlainTextResponse)
+def get_doc_template(slug: str) -> str:
+    try:
+        return get_template(slug)
+    except (ValueError, FileNotFoundError) as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.post("/generate-doc")
+def generate_doc(req: DocGenerateRequest) -> dict:
+    try:
+        html = render_generic_doc(req.doc_type, req.fields, req.title)
+        return {"html": html}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Rendering failed: {str(e)}")

--- a/backend/services/chat.py
+++ b/backend/services/chat.py
@@ -41,6 +41,7 @@ Party 2 fields:
 - Collect fields in this order: agreement fields first, then ALL Party 1 fields, then ALL Party 2 fields.
 - IMPORTANT: This is a MUTUAL NDA. Both parties must provide details. Do NOT skip or forget Party 2.
 - Keep replies concise and conversational.
+- If a user's response is unclear, ambiguous, or incomplete, ask a clarifying follow-on question before moving to the next field.
 - Always carry forward ALL previously collected fields in every response.
 - Before congratulating the user, check that every party1_* AND every party2_* field is non-null. If any are still null, ask for them.
 - Only when ALL 17 fields are non-null: congratulate the user and tell them to click "Download PDF".

--- a/backend/services/doc_chat.py
+++ b/backend/services/doc_chat.py
@@ -1,0 +1,188 @@
+import json
+import os
+import re
+from pathlib import Path
+
+from litellm import completion
+
+from models.chat import ChatMessage
+from models.doc_chat import DocChatResponse
+
+MODEL = "openrouter/arcee-ai/trinity-large-preview:free"
+EXTRA_BODY = {"provider": {"order": ["cerebras"]}}
+
+
+def _find_templates_dir() -> Path:
+    here = Path(__file__).parent.parent
+    for candidate in [here / "templates", here.parent / "templates"]:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"templates directory not found (searched from {here})")
+
+
+TEMPLATES_DIR = _find_templates_dir()
+
+SLUG_TO_FILENAME: dict[str, str] = {
+    "csa": "CSA.md",
+    "sla": "sla.md",
+    "design-partner-agreement": "design-partner-agreement.md",
+    "psa": "psa.md",
+    "dpa": "DPA.md",
+    "partnership-agreement": "Partnership-Agreement.md",
+    "software-license-agreement": "Software-License-Agreement.md",
+    "pilot-agreement": "Pilot-Agreement.md",
+    "baa": "BAA.md",
+    "ai-addendum": "AI-Addendum.md",
+}
+
+DOC_NAMES: dict[str, str] = {
+    "csa": "Cloud Service Agreement",
+    "sla": "Service Level Agreement",
+    "design-partner-agreement": "Design Partner Agreement",
+    "psa": "Professional Services Agreement",
+    "dpa": "Data Processing Agreement",
+    "partnership-agreement": "Partnership Agreement",
+    "software-license-agreement": "Software License Agreement",
+    "pilot-agreement": "Pilot Agreement",
+    "baa": "Business Associate Agreement",
+    "ai-addendum": "AI Addendum",
+}
+
+SUPPORTED_DOCS = [
+    "Mutual Non-Disclosure Agreement",
+    "Mutual NDA Cover Page",
+    "Cloud Service Agreement",
+    "Service Level Agreement",
+    "Design Partner Agreement",
+    "Professional Services Agreement",
+    "Data Processing Agreement",
+    "Partnership Agreement",
+    "Software License Agreement",
+    "Pilot Agreement",
+    "Business Associate Agreement",
+    "AI Addendum",
+]
+
+
+def get_template(slug: str) -> str:
+    """Return raw markdown for a document slug."""
+    filename = SLUG_TO_FILENAME.get(slug)
+    if not filename:
+        raise ValueError(f"Unknown document type: {slug}")
+    return (TEMPLATES_DIR / filename).read_text(encoding="utf-8")
+
+
+def _normalize(name: str) -> str:
+    """Normalize Unicode smart apostrophes to ASCII in field names."""
+    return name.replace("\u2019", "'").replace("\u2018", "'")
+
+
+def extract_fields(template_text: str) -> list[str]:
+    """Extract unique field names from span link markers in the template.
+
+    Normalizes smart apostrophes and skips possessive variants (e.g. "Customer's")
+    when the base form ("Customer") is already in the list — those are rendered
+    automatically during substitution.
+    """
+    pattern = r'<span class="(?:keyterms_link|coverpage_link|orderform_link|sow_link)">([^<]+)</span>'
+    matches = re.findall(pattern, template_text)
+    seen: set[str] = set()
+    fields: list[str] = []
+    for m in matches:
+        normalized = _normalize(m)
+        base = normalized[:-2] if normalized.endswith("'s") else None
+        if base is not None and base in seen:
+            continue  # possessive handled via base form
+        if normalized not in seen:
+            seen.add(normalized)
+            fields.append(normalized)
+    return fields
+
+
+def _build_messages(
+    doc_name: str,
+    fields_list: list[str],
+    conversation: list[ChatMessage],
+    current_fields: dict[str, str | None],
+) -> list[dict]:
+    field_state = json.dumps(current_fields, indent=2)
+    fields_bullet = "\n".join(f"- {f}" for f in fields_list)
+    supported_bullet = "\n".join(f"- {d}" for d in SUPPORTED_DOCS)
+
+    system = f"""\
+You are an AI legal assistant helping a user complete a {doc_name}.
+Your job is to have a friendly, conversational dialogue, asking questions one topic at a time to collect all required key terms.
+
+## Fields to collect
+{fields_bullet}
+
+## Rules
+- On the very first message greet the user warmly and ask your first question.
+- Collect fields one at a time in a logical order (parties first, then dates, then business terms).
+- Keep replies concise and conversational.
+- If a user's response is unclear, ambiguous, or incomplete, ask a clarifying follow-on question before moving to the next field.
+- Always carry forward ALL previously collected fields in every response.
+- Before congratulating the user, verify that every field above is non-null. If any are still null, ask for them.
+- Only when ALL fields are non-null: congratulate the user and tell them to click "Download PDF". Set "complete" to true.
+- If the user requests a document type not in the supported list, explain politely that it is not available and suggest the closest supported alternative.
+
+## Supported document types
+{supported_bullet}
+
+## Response format (JSON only — no extra text)
+{{
+  "reply": "<your message to the user>",
+  "fields": {{
+    <all field names from the list above, each mapped to a string value or null>
+  }},
+  "complete": false
+}}
+
+## Current field state
+```json
+{field_state}
+```"""
+
+    messages: list[dict] = [{"role": "system", "content": system}]
+    if not conversation:
+        messages.append({"role": "user", "content": "Please begin."})
+    else:
+        for msg in conversation:
+            messages.append({"role": msg.role, "content": msg.content})
+    return messages
+
+
+def call_doc_chat(
+    doc_type: str,
+    conversation: list[ChatMessage],
+    current_fields: dict[str, str | None],
+) -> DocChatResponse:
+    """Send conversation to LLM for a generic document type and return parsed response."""
+    template_text = get_template(doc_type)
+    fields_list = extract_fields(template_text)
+    doc_name = DOC_NAMES.get(doc_type, doc_type)
+
+    messages = _build_messages(doc_name, fields_list, conversation, current_fields)
+
+    response = completion(
+        model=MODEL,
+        messages=messages,
+        response_format={"type": "json_object"},
+        extra_body=EXTRA_BODY,
+        api_key=os.getenv("OPENROUTER_API_KEY"),
+    )
+
+    raw = response.choices[0].message.content
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"LLM returned non-JSON response: {exc}") from exc
+
+    if "reply" not in data:
+        raise ValueError("LLM response missing required 'reply' field")
+
+    return DocChatResponse(
+        reply=data["reply"],
+        fields={k: v for k, v in data.get("fields", {}).items()},
+        complete=bool(data.get("complete", False)),
+    )

--- a/backend/services/doc_renderer.py
+++ b/backend/services/doc_renderer.py
@@ -1,0 +1,103 @@
+import re
+
+import markdown as md_lib
+
+from services.doc_chat import DOC_NAMES, get_template
+
+
+def _normalize(name: str) -> str:
+    """Normalize Unicode smart apostrophes to ASCII."""
+    return name.replace("\u2019", "'").replace("\u2018", "'")
+
+
+def _replace_spans(text: str, fields: dict[str, str | None]) -> str:
+    """Replace all link span markers with their collected values.
+
+    Normalizes smart apostrophes in field names. For possessives like
+    "Customer's", falls back to the base form "Customer" + "'s".
+    """
+
+    def replace(match: re.Match) -> str:
+        normalized = _normalize(match.group(1))
+        value = fields.get(normalized)
+        if value:
+            return value
+        if normalized.endswith("'s"):
+            base_value = fields.get(normalized[:-2])
+            if base_value:
+                return f"{base_value}'s"
+        return f"[{normalized}]"
+
+    return re.sub(
+        r'<span class="(?:keyterms_link|coverpage_link|orderform_link|sow_link)">([^<]+)</span>',
+        replace,
+        text,
+    )
+
+
+def _build_key_terms_section(fields: dict[str, str | None]) -> str:
+    """Build an HTML key terms summary from collected fields."""
+    filled = {k: v for k, v in fields.items() if v}
+    if not filled:
+        return ""
+
+    rows = "".join(
+        f'<tr><td style="font-weight:bold;padding:6px 12px 6px 0;vertical-align:top;white-space:nowrap;">{k}</td>'
+        f'<td style="padding:6px 0;">{v}</td></tr>'
+        for k, v in filled.items()
+    )
+
+    return f"""<div style="border:1px solid #ccc;padding:16px;margin-bottom:24px;background:#fafafa;">
+<h2 style="margin-top:0;font-size:14pt;">Key Terms</h2>
+<table style="border-collapse:collapse;width:100%;">{rows}</table>
+</div>"""
+
+
+def render_generic_doc(
+    doc_type: str,
+    fields: dict[str, str | None],
+    title: str = "",
+) -> str:
+    """Render a generic legal document template to a printable HTML string."""
+    template_md = get_template(doc_type)
+    doc_name = title or DOC_NAMES.get(doc_type, doc_type)
+
+    text = _replace_spans(template_md, fields)
+    body_html = md_lib.markdown(text, extensions=["tables"])
+    key_terms_html = _build_key_terms_section(fields)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{doc_name}</title>
+  <style>
+    body {{
+      font-family: 'Times New Roman', Times, serif;
+      font-size: 11pt;
+      line-height: 1.6;
+      color: #000;
+      max-width: 816px;
+      margin: 0 auto;
+      padding: 1in;
+    }}
+    h1 {{ font-size: 16pt; text-align: center; }}
+    h2 {{ font-size: 13pt; }}
+    h3 {{ font-size: 11pt; }}
+    table {{ width: 100%; border-collapse: collapse; margin: 1rem 0; }}
+    td, th {{ border: 1px solid #000; padding: 8px; }}
+    @page {{ size: letter; margin: 1in; }}
+    @media print {{
+      body {{ padding: 0; max-width: 100%; }}
+    }}
+  </style>
+</head>
+<body>
+  <h1>{doc_name}</h1>
+  {key_terms_html}
+  <div class="standard-terms">
+    {body_html}
+  </div>
+</body>
+</html>"""

--- a/backend/tests/test_doc_chat.py
+++ b/backend/tests/test_doc_chat.py
@@ -1,0 +1,145 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.doc_chat import DOC_NAMES, SLUG_TO_FILENAME, extract_fields, get_template
+
+
+# --- Unit tests for doc_chat service ---
+
+
+def test_slug_to_filename_covers_all_slugs():
+    assert "csa" in SLUG_TO_FILENAME
+    assert "sla" in SLUG_TO_FILENAME
+    assert "psa" in SLUG_TO_FILENAME
+    # mutual-nda-coverpage uses literal placeholders, not spans — served via /nda instead
+    assert "mutual-nda-coverpage" not in SLUG_TO_FILENAME
+
+
+def test_doc_names_cover_all_slugs():
+    assert set(DOC_NAMES.keys()) == set(SLUG_TO_FILENAME.keys())
+
+
+def test_get_template_csa_loads():
+    text = get_template("csa")
+    assert len(text) > 100
+    assert "Cloud Service Agreement" in text or "Service" in text
+
+
+def test_get_template_unknown_slug_raises():
+    with pytest.raises(ValueError, match="Unknown document type"):
+        get_template("nonexistent-doc")
+
+
+def test_extract_fields_from_csa():
+    template = get_template("csa")
+    fields = extract_fields(template)
+    assert "Customer" in fields
+    assert "Provider" in fields
+    # No duplicates
+    assert len(fields) == len(set(fields))
+
+
+def test_extract_fields_empty_template():
+    assert extract_fields("No spans here.") == []
+
+
+def test_extract_fields_various_span_types():
+    template = (
+        '<span class="keyterms_link">Customer</span> and '
+        '<span class="coverpage_link">Provider</span> agree. '
+        '<span class="orderform_link">Subscription Period</span> is 1 year. '
+        '<span class="sow_link">Deliverables</span> are listed. '
+        '<span class="header_2">Section Title</span> is ignored.'
+    )
+    fields = extract_fields(template)
+    assert fields == ["Customer", "Provider", "Subscription Period", "Deliverables"]
+
+
+def test_extract_fields_deduplicates():
+    template = (
+        '<span class="keyterms_link">Customer</span> '
+        '<span class="keyterms_link">Customer</span>'
+    )
+    fields = extract_fields(template)
+    assert fields == ["Customer"]
+
+
+def test_extract_fields_normalizes_smart_apostrophe():
+    template = (
+        '<span class="keyterms_link">Customer</span> and '
+        '<span class="keyterms_link">Customer\u2019s</span>'
+    )
+    fields = extract_fields(template)
+    # "Customer's" is a possessive of "Customer" — should be omitted
+    assert "Customer" in fields
+    assert "Customer\u2019s" not in fields
+    assert "Customer's" not in fields
+
+
+def test_replace_spans_resolves_possessive_via_base():
+    from services.doc_renderer import _replace_spans
+
+    text = '<span class="keyterms_link">Customer\u2019s</span> obligation'
+    result = _replace_spans(text, {"Customer": "Acme Corp"})
+    assert "Acme Corp's" in result
+
+
+# --- API tests for /api/doc-chat ---
+
+
+async def test_doc_chat_returns_200(client):
+    mock_choice = MagicMock()
+    mock_choice.message.content = (
+        '{"reply": "Hello! What is the name of the Customer?", '
+        '"fields": {"Customer": null, "Provider": null}, "complete": false}'
+    )
+    mock_completion = MagicMock()
+    mock_completion.choices = [mock_choice]
+
+    with patch("services.doc_chat.completion", return_value=mock_completion):
+        r = await client.post(
+            "/api/doc-chat",
+            json={"doc_type": "csa", "messages": [], "current_fields": {}},
+        )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert "reply" in data
+    assert "fields" in data
+    assert "complete" in data
+
+
+async def test_doc_chat_unknown_doc_type_returns_400(client):
+    r = await client.post(
+        "/api/doc-chat",
+        json={"doc_type": "unknown-doc", "messages": [], "current_fields": {}},
+    )
+    assert r.status_code == 400
+
+
+async def test_doc_template_endpoint_returns_text(client):
+    r = await client.get("/api/doc-templates/csa")
+    assert r.status_code == 200
+    assert "Cloud Service Agreement" in r.text or len(r.text) > 100
+
+
+async def test_doc_template_unknown_slug_returns_404(client):
+    r = await client.get("/api/doc-templates/nonexistent")
+    assert r.status_code == 404
+
+
+async def test_generate_doc_returns_html(client):
+    r = await client.post(
+        "/api/generate-doc",
+        json={
+            "doc_type": "csa",
+            "fields": {"Customer": "Acme Corp", "Provider": "Tech Inc"},
+            "title": "Cloud Service Agreement",
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert "html" in data
+    assert "Acme Corp" in data["html"]
+    assert "Tech Inc" in data["html"]

--- a/backend/tests/test_doc_renderer.py
+++ b/backend/tests/test_doc_renderer.py
@@ -1,0 +1,50 @@
+from services.doc_renderer import _replace_spans, render_generic_doc
+
+
+def test_replace_spans_fills_values():
+    text = '<span class="keyterms_link">Customer</span> and <span class="keyterms_link">Provider</span>'
+    result = _replace_spans(text, {"Customer": "Acme Corp", "Provider": "Tech Inc"})
+    assert "Acme Corp" in result
+    assert "Tech Inc" in result
+    assert "keyterms_link" not in result
+
+
+def test_replace_spans_uses_placeholder_for_missing():
+    text = '<span class="keyterms_link">Customer</span>'
+    result = _replace_spans(text, {})
+    assert "[Customer]" in result
+
+
+def test_replace_spans_all_link_types():
+    text = (
+        '<span class="keyterms_link">A</span> '
+        '<span class="coverpage_link">B</span> '
+        '<span class="orderform_link">C</span> '
+        '<span class="sow_link">D</span>'
+    )
+    result = _replace_spans(text, {"A": "1", "B": "2", "C": "3", "D": "4"})
+    assert "1" in result
+    assert "2" in result
+    assert "3" in result
+    assert "4" in result
+
+
+def test_render_generic_doc_returns_html():
+    html = render_generic_doc("csa", {"Customer": "Acme", "Provider": "Tech Inc"})
+    assert "<!DOCTYPE html>" in html
+    assert "Acme" in html
+    assert "Tech Inc" in html
+
+
+def test_render_generic_doc_includes_key_terms():
+    html = render_generic_doc("psa", {"Customer": "BigCo", "Provider": "SmallCo"})
+    assert "Key Terms" in html
+    assert "BigCo" in html
+    assert "SmallCo" in html
+
+
+def test_render_generic_doc_empty_fields_shows_placeholders():
+    html = render_generic_doc("csa", {})
+    # Should still produce valid HTML
+    assert "<!DOCTYPE html>" in html
+    assert "[Customer]" in html or "[Provider]" in html

--- a/frontend/src/app/doc/[slug]/DocChatClient.tsx
+++ b/frontend/src/app/doc/[slug]/DocChatClient.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import {
+  DocChatMessage,
+  fetchDocTemplate,
+  generateDoc,
+  sendDocChatMessage,
+} from "@/lib/docChatApi";
+import { renderGenericTemplate } from "@/lib/genericRenderer";
+import { ChatPanel } from "@/components/chat/ChatPanel";
+import { printDocument } from "@/lib/printDocument";
+
+const DOC_NAMES: Record<string, string> = {
+  csa: "Cloud Service Agreement",
+  sla: "Service Level Agreement",
+  "design-partner-agreement": "Design Partner Agreement",
+  psa: "Professional Services Agreement",
+  dpa: "Data Processing Agreement",
+  "partnership-agreement": "Partnership Agreement",
+  "software-license-agreement": "Software License Agreement",
+  "pilot-agreement": "Pilot Agreement",
+  baa: "Business Associate Agreement",
+  "ai-addendum": "AI Addendum",
+};
+
+interface Props {
+  slug: string;
+}
+
+export function DocChatClient({ slug }: Props) {
+  const docName = DOC_NAMES[slug] ?? slug;
+
+  const [messages, setMessages] = useState<DocChatMessage[]>([]);
+  const [currentFields, setCurrentFields] = useState<Record<string, string | null>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [chatError, setChatError] = useState<string | null>(null);
+  const [templateMd, setTemplateMd] = useState<string>("");
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  // Load template for live preview
+  useEffect(() => {
+    fetchDocTemplate(slug)
+      .then(setTemplateMd)
+      .catch(() => {});
+  }, [slug]);
+
+  // Greet user on mount
+  useEffect(() => {
+    async function greet() {
+      setIsLoading(true);
+      try {
+        const res = await sendDocChatMessage(slug, [], {});
+        setMessages([{ role: "assistant", content: res.reply }]);
+        setCurrentFields(res.fields);
+      } catch {
+        setChatError("Failed to connect to the AI. Please refresh and try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    greet();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slug]);
+
+  const handleSend = useCallback(
+    async (text: string) => {
+      const userMsg: DocChatMessage = { role: "user", content: text };
+      const updatedMessages = [...messages, userMsg];
+      setMessages(updatedMessages);
+      setIsLoading(true);
+      setChatError(null);
+
+      try {
+        const res = await sendDocChatMessage(slug, updatedMessages, currentFields);
+        setMessages([...updatedMessages, { role: "assistant", content: res.reply }]);
+        setCurrentFields(res.fields);
+      } catch {
+        setChatError("Something went wrong. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [messages, currentFields, slug]
+  );
+
+  const previewHtml = useMemo(() => {
+    if (!templateMd) return "";
+    return renderGenericTemplate(templateMd, currentFields);
+  }, [templateMd, currentFields]);
+
+  async function handleDownload() {
+    setIsGenerating(true);
+    try {
+      const { html } = await generateDoc(slug, currentFields, docName);
+      printDocument(html);
+    } catch {
+      setChatError("Failed to generate document. Please try again.");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  return (
+    <div className="h-screen flex flex-col">
+      {/* Header */}
+      <header className="bg-brand-navy text-white px-6 py-3 flex items-center justify-between shrink-0">
+        <div>
+          <Link href="/" className="text-xs text-brand-gray hover:text-white mr-3">
+            ← Back
+          </Link>
+          <span className="font-semibold text-sm">{docName}</span>
+        </div>
+        <button
+          onClick={handleDownload}
+          disabled={isGenerating}
+          className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90 disabled:opacity-50"
+        >
+          {isGenerating ? "Generating..." : "Download PDF"}
+        </button>
+      </header>
+
+      {/* Main split pane */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left: Chat */}
+        <div className="w-2/5 flex flex-col border-r border-gray-200 bg-white">
+          <div className="px-4 py-3 border-b border-gray-100 shrink-0">
+            <p className="text-xs font-medium text-brand-navy">AI Assistant</p>
+            <p className="text-xs text-brand-gray">Answers update the document preview live</p>
+          </div>
+
+          {chatError && (
+            <div className="px-4 py-2 text-xs text-red-600 bg-red-50 border-b border-red-100">
+              {chatError}
+            </div>
+          )}
+          <div className="flex-1 overflow-hidden">
+            <ChatPanel messages={messages} isLoading={isLoading} onSend={handleSend} />
+          </div>
+        </div>
+
+        {/* Right: Document preview */}
+        <div className="flex-1 flex flex-col bg-gray-50 overflow-hidden">
+          <div className="px-6 py-3 border-b border-gray-200 shrink-0">
+            <p className="text-xs font-medium text-brand-navy">Document Preview</p>
+            <p className="text-xs text-brand-gray">Updates as you chat</p>
+          </div>
+          <div className="flex-1 overflow-auto p-6">
+            {previewHtml ? (
+              <div
+                className="bg-white rounded-lg shadow-sm p-8 prose prose-sm max-w-none"
+                dangerouslySetInnerHTML={{ __html: previewHtml }}
+              />
+            ) : (
+              <div className="flex items-center justify-center h-full text-brand-gray text-sm">
+                Loading document preview...
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/doc/[slug]/page.tsx
+++ b/frontend/src/app/doc/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { DocChatClient } from "./DocChatClient";
+
+const SLUGS = [
+  "csa",
+  "sla",
+  "design-partner-agreement",
+  "psa",
+  "dpa",
+  "partnership-agreement",
+  "software-license-agreement",
+  "pilot-agreement",
+  "baa",
+  "ai-addendum",
+];
+
+export function generateStaticParams() {
+  return SLUGS.map((slug) => ({ slug }));
+}
+
+export default function DocPage({ params }: { params: { slug: string } }) {
+  return <DocChatClient slug={params.slug} />;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001";
 
 interface CatalogItem {
   name: string;
@@ -11,9 +11,18 @@ interface CatalogItem {
   filename: string;
 }
 
-const AVAILABLE: Record<string, string> = {
+// Documents that use a special dedicated route
+const SPECIAL_ROUTES: Record<string, string> = {
   "Mutual Non-Disclosure Agreement": "/nda",
+  "Mutual NDA Cover Page": "/nda",
 };
+
+function getRoute(item: CatalogItem): string {
+  if (SPECIAL_ROUTES[item.name]) return SPECIAL_ROUTES[item.name];
+  // Derive slug from template filename: "templates/CSA.md" → "csa"
+  const slug = item.filename.replace("templates/", "").replace(".md", "").toLowerCase();
+  return `/doc/${slug}`;
+}
 
 export default function HomePage() {
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);
@@ -50,8 +59,8 @@ export default function HomePage() {
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {catalog.map((item) => {
-              const href = AVAILABLE[item.name];
-              return href ? (
+              const href = getRoute(item);
+              return (
                 <Link
                   key={item.name}
                   href={href}
@@ -67,21 +76,6 @@ export default function HomePage() {
                     Create →
                   </span>
                 </Link>
-              ) : (
-                <div
-                  key={item.name}
-                  className="bg-white rounded-lg border border-gray-100 p-5 opacity-60 cursor-not-allowed"
-                >
-                  <h2 className="font-semibold text-brand-navy mb-2 text-sm">
-                    {item.name}
-                  </h2>
-                  <p className="text-xs text-brand-gray leading-relaxed">
-                    {item.description}
-                  </p>
-                  <span className="mt-3 inline-block text-xs font-medium text-brand-gray">
-                    Coming soon
-                  </span>
-                </div>
               );
             })}
           </div>

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ChatMessage } from "@/lib/chatApi";
+
+interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
 
 interface ChatPanelProps {
-  messages: ChatMessage[];
+  messages: Message[];
   isLoading: boolean;
   onSend: (text: string) => void;
 }
@@ -12,10 +16,17 @@ interface ChatPanelProps {
 export function ChatPanel({ messages, isLoading, onSend }: ChatPanelProps) {
   const [input, setInput] = useState("");
   const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading]);
+
+  useEffect(() => {
+    if (!isLoading) {
+      inputRef.current?.focus();
+    }
+  }, [isLoading]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -67,6 +78,7 @@ export function ChatPanel({ messages, isLoading, onSend }: ChatPanelProps) {
         className="border-t border-gray-200 px-4 py-3 flex gap-2"
       >
         <input
+          ref={inputRef}
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}

--- a/frontend/src/lib/__tests__/genericRenderer.test.ts
+++ b/frontend/src/lib/__tests__/genericRenderer.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { renderGenericTemplate } from "../genericRenderer";
+
+describe("renderGenericTemplate", () => {
+  it("replaces keyterms_link spans with field values", () => {
+    const template = '<span class="keyterms_link">Customer</span>';
+    const result = renderGenericTemplate(template, { Customer: "Acme Corp" });
+    expect(result).toContain("Acme Corp");
+    expect(result).not.toContain("keyterms_link");
+  });
+
+  it("replaces coverpage_link spans", () => {
+    const template = '<span class="coverpage_link">Provider</span>';
+    const result = renderGenericTemplate(template, { Provider: "Tech Inc" });
+    expect(result).toContain("Tech Inc");
+  });
+
+  it("replaces orderform_link spans", () => {
+    const template = '<span class="orderform_link">Subscription Period</span>';
+    const result = renderGenericTemplate(template, { "Subscription Period": "1 year" });
+    expect(result).toContain("1 year");
+  });
+
+  it("replaces sow_link spans", () => {
+    const template = '<span class="sow_link">Deliverables</span>';
+    const result = renderGenericTemplate(template, { Deliverables: "Software" });
+    expect(result).toContain("Software");
+  });
+
+  it("shows styled placeholder for missing fields", () => {
+    const template = '<span class="keyterms_link">Customer</span>';
+    const result = renderGenericTemplate(template, {});
+    expect(result).toContain("[Customer]");
+  });
+
+  it("escapes HTML in field values to prevent XSS", () => {
+    const template = '<span class="keyterms_link">Customer</span>';
+    const result = renderGenericTemplate(template, { Customer: '<script>alert("xss")</script>' });
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("&lt;script&gt;");
+  });
+
+  it("handles null field values with placeholder", () => {
+    const template = '<span class="keyterms_link">Customer</span>';
+    const result = renderGenericTemplate(template, { Customer: null });
+    expect(result).toContain("[Customer]");
+  });
+
+  it("normalizes smart apostrophe (U+2019) in field names", () => {
+    // Template uses a Unicode smart apostrophe; LLM returns ASCII apostrophe key
+    const template = '<span class="keyterms_link">Customer\u2019s</span>';
+    const result = renderGenericTemplate(template, { "Customer's": "Acme Corp's" });
+    expect(result).toContain("Acme Corp");
+    expect(result).not.toContain("[Customer");
+  });
+
+  it("resolves possessive via base form when available", () => {
+    const template = '<span class="keyterms_link">Customer\u2019s</span>';
+    const result = renderGenericTemplate(template, { Customer: "Acme Corp" });
+    expect(result).toContain("Acme Corp");
+  });
+
+  it("renders markdown to HTML", () => {
+    const template = "# Agreement\n\nThis is an agreement between parties.";
+    const result = renderGenericTemplate(template, {});
+    expect(result).toContain("<h1>");
+    expect(result).toContain("Agreement");
+  });
+});

--- a/frontend/src/lib/chatApi.ts
+++ b/frontend/src/lib/chatApi.ts
@@ -1,4 +1,4 @@
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001";
 
 export interface ChatNdaFields {
   purpose: string | null;

--- a/frontend/src/lib/docChatApi.ts
+++ b/frontend/src/lib/docChatApi.ts
@@ -1,0 +1,62 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001";
+
+export interface DocChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface DocChatResponse {
+  reply: string;
+  fields: Record<string, string | null>;
+  complete: boolean;
+}
+
+export async function sendDocChatMessage(
+  docType: string,
+  messages: DocChatMessage[],
+  currentFields: Record<string, string | null>
+): Promise<DocChatResponse> {
+  const response = await fetch(`${API_BASE}/api/doc-chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      doc_type: docType,
+      messages,
+      current_fields: currentFields,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Chat error: ${error}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchDocTemplate(slug: string): Promise<string> {
+  const response = await fetch(`${API_BASE}/api/doc-templates/${slug}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch template: ${slug}`);
+  }
+  return response.text();
+}
+
+export async function generateDoc(
+  docType: string,
+  fields: Record<string, string | null>,
+  title: string
+): Promise<{ html: string }> {
+  const response = await fetch(`${API_BASE}/api/generate-doc`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ doc_type: docType, fields, title }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Failed to generate document: ${error}`);
+  }
+
+  return response.json();
+}

--- a/frontend/src/lib/genericRenderer.ts
+++ b/frontend/src/lib/genericRenderer.ts
@@ -1,0 +1,43 @@
+import { marked } from "marked";
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+function normalize(name: string): string {
+  return name.replace(/\u2019/g, "'").replace(/\u2018/g, "'");
+}
+
+/**
+ * Render a generic legal document template with collected field values.
+ * Replaces all keyterms_link, coverpage_link, orderform_link, sow_link spans.
+ * Normalizes smart apostrophes and resolves possessives via the base form.
+ */
+export function renderGenericTemplate(
+  templateMd: string,
+  fields: Record<string, string | null>
+): string {
+  const text = templateMd.replace(
+    /<span class="(?:keyterms_link|coverpage_link|orderform_link|sow_link)">([^<]+)<\/span>/g,
+    (_, rawName: string) => {
+      const fieldName = normalize(rawName);
+      const value = fields[fieldName];
+      if (value) return `<strong>${escapeHtml(value)}</strong>`;
+
+      // For possessives like "Customer's", fall back to base form + "'s"
+      if (fieldName.endsWith("'s")) {
+        const baseValue = fields[fieldName.slice(0, -2)];
+        if (baseValue) return `<strong>${escapeHtml(baseValue)}'s</strong>`;
+      }
+
+      return `<span style="color:#aaa;font-style:italic;">[${escapeHtml(fieldName)}]</span>`;
+    }
+  );
+
+  return marked.parse(text) as string;
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **PL-6**: All 10 remaining document types now fully supported (CSA, SLA, PSA, DPA, Partnership Agreement, Software License Agreement, Pilot Agreement, BAA, AI Addendum, Design Partner Agreement)
- Every catalog item on the home page is now clickable — routing to `/doc/[slug]` for generic docs, `/nda` for Mutual NDA
- AI chat guides the user through collecting all key terms for any document, and offers alternatives if asked for an unsupported type
- **Fix**: UI focus returns to the text input after each AI response
- **Fix**: AI system prompts updated to ask clarifying follow-on questions when a user's response is ambiguous or incomplete
- **Fix**: Default API base URL corrected to `localhost:8001` in `chatApi.ts` and `page.tsx`

## What changed

### Backend
- `backend/models/doc_chat.py` — `DocChatRequest`, `DocChatResponse`, `DocGenerateRequest` models
- `backend/services/doc_chat.py` — generic chat service: loads template, extracts fields from span markers (normalizing U+2019 smart apostrophes), builds system prompt, calls LiteLLM
- `backend/services/doc_renderer.py` — span substitution renderer with possessive form resolution (`Customer's` → base form `Customer` + `'s`)
- `backend/routers/doc_chat.py` — `POST /api/doc-chat`, `GET /api/doc-templates/{slug}`, `POST /api/generate-doc`
- `backend/main.py` — registered new router

### Frontend
- `frontend/src/app/doc/[slug]/page.tsx` + `DocChatClient.tsx` — generic document chat page (10 slugs pre-rendered via `generateStaticParams`)
- `frontend/src/lib/docChatApi.ts` — API client for generic doc chat
- `frontend/src/lib/genericRenderer.ts` — client-side template renderer with smart-apostrophe normalization and XSS escaping
- `frontend/src/app/page.tsx` — all catalog items clickable; slug derived from template filename
- `frontend/src/components/chat/ChatPanel.tsx` — focus fix; message type made generic

## Test plan

- [ ] All catalog items on home page are clickable (no more "Coming soon")
- [ ] Clicking CSA/PSA/SLA etc. opens chat UI with AI greeting and document preview
- [ ] AI asks one question at a time and asks follow-on questions when needed
- [ ] Text input is focused automatically after each AI response
- [ ] Document preview updates live as fields are collected
- [ ] "Download PDF" generates a complete document with key terms summary
- [ ] Asking for an unsupported document type in chat gets a polite explanation and suggestion
- [ ] Mutual NDA still works unchanged
- [ ] 59 backend tests + 53 frontend tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)