### PR TITLE
feat: authentication, document history & UI polish (PL-7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The available documents are covered in the catalog.json file in the project root
 
 @catalog.json
 
-The current implementation supports the Mutual NDA document with AI chat for field collection.
+The current implementation supports all 12 document templates with AI chat for field collection.
 
 ## Development process
 
@@ -73,6 +73,27 @@ Backend available at http://localhost:8001 (docker-compose maps 8001→8000 insi
 - "Download PDF" button available at any time — opens signature modal (canvas pads for both parties) then generates PDF
 - docker-compose.yml passes OPENROUTER_API_KEY via env_file; .dockerignore excludes **/.next and **/out
 
-### Not Yet Implemented
-- Functional authentication (signup/signin/session management)
-- Support for other document templates beyond Mutual NDA
+### Completed (PL-6)
+- All 12 document templates now supported with generic AI chat, live preview, and PDF download
+- Generic doc routes at /doc/[slug] with split-pane UI (chat left, document preview right)
+- POST /api/doc-chat, GET /api/doc-templates/{slug}, POST /api/generate-doc backend routes
+- Field extraction from span markers (keyterms_link, coverpage_link, orderform_link, sow_link)
+- Smart apostrophe normalization and possessive-form resolution for field names
+- Mutual NDA Cover Page uses bracket placeholder substitution (hardcoded field list)
+- Header spans (header_2, header_3) converted to bold markdown for proper rendering
+- Shared doc-content CSS class for consistent document preview styling across all templates
+- Chat input auto-focuses after AI response; AI asks follow-on questions when info is incomplete
+- Templates sourced from Common Paper (https://commonpaper.com), licensed CC BY 4.0
+
+### Completed (PL-7)
+- Functional authentication: signup/signin with bcrypt password hashing, cookie-based sessions
+- Tabbed login page (sign in / sign up) with real error handling
+- Auth guard on all pages — unauthenticated users redirected to /login
+- POST /api/auth/signup, POST /api/auth/signin, POST /api/auth/signout, GET /api/auth/me
+- Document history: documents saved to SQLite on PDF download, shown on home page
+- POST /api/documents (save), GET /api/documents (list user's documents)
+- My Documents section on home page with preview modal and re-download
+- Consistent NavBar component across all pages (logo, user email, sign out)
+- Disclaimer on login page, home page footer, editor page banners, and generated PDFs
+- UI polish: professional consistent styling, fixed stale login API_BASE port
+- sessions and documents tables in SQLite (ephemeral, reset on container restart)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY backend/pyproject.toml backend/uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project --link-mode=copy
 
+# Install Playwright Chromium and its system dependencies
+RUN uv run playwright install --with-deps chromium
+
 # Copy backend source, templates, and catalog
 COPY backend/ ./
 COPY templates/ ./templates/

--- a/backend/database.py
+++ b/backend/database.py
@@ -43,7 +43,9 @@ def init_db() -> None:
             fields_json TEXT NOT NULL,
             html TEXT NOT NULL,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (user_id) REFERENCES users(id)
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            UNIQUE (user_id, doc_type)
         )
     """)
     conn.commit()

--- a/backend/database.py
+++ b/backend/database.py
@@ -5,8 +5,15 @@ from pathlib import Path
 DB_PATH = os.getenv("DB_PATH", "prelegal.db")
 
 
+def get_db() -> sqlite3.Connection:
+    """Return a connection to the database with row_factory set."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
 def init_db() -> None:
-    """Drop and recreate the database with a fresh users table."""
+    """Drop and recreate the database with fresh tables."""
     db_file = Path(DB_PATH)
     if db_file.exists():
         db_file.unlink()
@@ -17,6 +24,26 @@ def init_db() -> None:
             email TEXT UNIQUE NOT NULL,
             password_hash TEXT NOT NULL,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            user_id INTEGER NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            doc_type TEXT NOT NULL,
+            title TEXT NOT NULL,
+            fields_json TEXT NOT NULL,
+            html TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id)
         )
     """)
     conn.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from routers.auth import router as auth_router
 from routers.catalog import router as catalog_router
 from routers.chat import router as chat_router
 from routers.doc_chat import router as doc_chat_router
+from routers.documents import router as documents_router
 from routers.generate import router as generate_router
 
 load_dotenv()
@@ -39,6 +40,7 @@ app.include_router(auth_router)
 app.include_router(catalog_router)
 app.include_router(chat_router)
 app.include_router(doc_chat_router)
+app.include_router(documents_router)
 app.include_router(generate_router)
 
 # Serve the static Next.js export when available (Docker production)

--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, EmailStr
+
+
+class SignupRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class SigninRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class AuthResponse(BaseModel):
+    email: str

--- a/backend/models/documents.py
+++ b/backend/models/documents.py
@@ -13,4 +13,15 @@ class DocumentRecord(BaseModel):
     doc_type: str
     title: str
     created_at: str
+    updated_at: str
     html: str
+
+
+class DocumentDetail(BaseModel):
+    id: int
+    doc_type: str
+    title: str
+    created_at: str
+    updated_at: str
+    html: str
+    fields: dict

--- a/backend/models/documents.py
+++ b/backend/models/documents.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class SaveDocumentRequest(BaseModel):
+    doc_type: str
+    title: str
+    fields: dict
+    html: str
+
+
+class DocumentRecord(BaseModel):
+    id: int
+    doc_type: str
+    title: str
+    created_at: str
+    html: str

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,11 +6,12 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.111.0",
     "uvicorn[standard]>=0.29.0",
-    "pydantic>=2.7.1",
+    "pydantic[email]>=2.7.1",
     "python-multipart>=0.0.9",
     "python-dotenv>=1.0.1",
     "markdown>=3.6",
     "litellm>=1.82.6",
+    "bcrypt>=5.0.0",
 ]
 
 [dependency-groups]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "markdown>=3.6",
     "litellm>=1.82.6",
     "bcrypt>=5.0.0",
+    "playwright>=1.52.0",
+    "fpdf2>=2.8.7",
 ]
 
 [dependency-groups]

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,18 +1,77 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Cookie, HTTPException, Response
+
+from database import get_db
+from models.auth import AuthResponse, SigninRequest, SignupRequest
+from services.auth import (
+    create_session,
+    get_user_by_session,
+    hash_password,
+    verify_password,
+)
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 
-@router.post("/signup", status_code=501)
-async def signup():
-    raise HTTPException(status_code=501, detail="Not implemented")
+@router.post("/signup", response_model=AuthResponse)
+async def signup(req: SignupRequest, response: Response):
+    if len(req.password) < 8:
+        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
+    db = get_db()
+    try:
+        existing = db.execute("SELECT id FROM users WHERE email = ?", (req.email,)).fetchone()
+        if existing:
+            raise HTTPException(status_code=409, detail="Email already registered")
+        cursor = db.execute(
+            "INSERT INTO users (email, password_hash) VALUES (?, ?)",
+            (req.email, hash_password(req.password)),
+        )
+        db.commit()
+        user_id = cursor.lastrowid
+    finally:
+        db.close()
+    token = create_session(user_id)
+    response.set_cookie(
+        "session", token, httponly=True, samesite="lax", max_age=86400,
+    )
+    return AuthResponse(email=req.email)
 
 
-@router.post("/signin", status_code=501)
-async def signin():
-    raise HTTPException(status_code=501, detail="Not implemented")
+@router.post("/signin", response_model=AuthResponse)
+async def signin(req: SigninRequest, response: Response):
+    db = get_db()
+    try:
+        row = db.execute(
+            "SELECT id, email, password_hash FROM users WHERE email = ?", (req.email,),
+        ).fetchone()
+    finally:
+        db.close()
+    if not row or not verify_password(req.password, row["password_hash"]):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+    token = create_session(row["id"])
+    response.set_cookie(
+        "session", token, httponly=True, samesite="lax", max_age=86400,
+    )
+    return AuthResponse(email=row["email"])
 
 
-@router.get("/me", status_code=401)
-async def me():
-    raise HTTPException(status_code=401, detail="Unauthorized")
+@router.post("/signout")
+async def signout(response: Response, session: str | None = Cookie(None)):
+    if session:
+        db = get_db()
+        try:
+            db.execute("DELETE FROM sessions WHERE id = ?", (session,))
+            db.commit()
+        finally:
+            db.close()
+    response.delete_cookie("session")
+    return {"ok": True}
+
+
+@router.get("/me", response_model=AuthResponse)
+async def me(session: str | None = Cookie(None)):
+    if not session:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    user = get_user_by_session(session)
+    if not user:
+        raise HTTPException(status_code=401, detail="Session expired")
+    return AuthResponse(email=user["email"])

--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -1,0 +1,46 @@
+import json
+
+from fastapi import APIRouter, Depends
+
+from database import get_db
+from models.documents import DocumentRecord, SaveDocumentRequest
+from services.auth import require_session
+
+router = APIRouter(prefix="/api", tags=["documents"])
+
+
+@router.post("/documents", status_code=201)
+async def save_document(req: SaveDocumentRequest, user: dict = Depends(require_session)):
+    db = get_db()
+    try:
+        cursor = db.execute(
+            "INSERT INTO documents (user_id, doc_type, title, fields_json, html) VALUES (?, ?, ?, ?, ?)",
+            (user["id"], req.doc_type, req.title, json.dumps(req.fields), req.html),
+        )
+        db.commit()
+        doc_id = cursor.lastrowid
+    finally:
+        db.close()
+    return {"id": doc_id}
+
+
+@router.get("/documents", response_model=list[DocumentRecord])
+async def list_documents(user: dict = Depends(require_session)):
+    db = get_db()
+    try:
+        rows = db.execute(
+            "SELECT id, doc_type, title, created_at, html FROM documents WHERE user_id = ? ORDER BY created_at DESC",
+            (user["id"],),
+        ).fetchall()
+    finally:
+        db.close()
+    return [
+        DocumentRecord(
+            id=r["id"],
+            doc_type=r["doc_type"],
+            title=r["title"],
+            created_at=str(r["created_at"]),
+            html=r["html"],
+        )
+        for r in rows
+    ]

--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -1,9 +1,9 @@
 import json
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from database import get_db
-from models.documents import DocumentRecord, SaveDocumentRequest
+from models.documents import DocumentDetail, DocumentRecord, SaveDocumentRequest
 from services.auth import require_session
 
 router = APIRouter(prefix="/api", tags=["documents"])
@@ -13,12 +13,22 @@ router = APIRouter(prefix="/api", tags=["documents"])
 async def save_document(req: SaveDocumentRequest, user: dict = Depends(require_session)):
     db = get_db()
     try:
-        cursor = db.execute(
-            "INSERT INTO documents (user_id, doc_type, title, fields_json, html) VALUES (?, ?, ?, ?, ?)",
+        db.execute(
+            """INSERT INTO documents (user_id, doc_type, title, fields_json, html)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(user_id, doc_type) DO UPDATE SET
+                title = excluded.title,
+                fields_json = excluded.fields_json,
+                html = excluded.html,
+                updated_at = CURRENT_TIMESTAMP""",
             (user["id"], req.doc_type, req.title, json.dumps(req.fields), req.html),
         )
         db.commit()
-        doc_id = cursor.lastrowid
+        row = db.execute(
+            "SELECT id FROM documents WHERE user_id = ? AND doc_type = ?",
+            (user["id"], req.doc_type),
+        ).fetchone()
+        doc_id = row["id"]
     finally:
         db.close()
     return {"id": doc_id}
@@ -29,7 +39,7 @@ async def list_documents(user: dict = Depends(require_session)):
     db = get_db()
     try:
         rows = db.execute(
-            "SELECT id, doc_type, title, created_at, html FROM documents WHERE user_id = ? ORDER BY created_at DESC",
+            "SELECT id, doc_type, title, created_at, updated_at, html FROM documents WHERE user_id = ? ORDER BY updated_at DESC",
             (user["id"],),
         ).fetchall()
     finally:
@@ -40,7 +50,31 @@ async def list_documents(user: dict = Depends(require_session)):
             doc_type=r["doc_type"],
             title=r["title"],
             created_at=str(r["created_at"]),
+            updated_at=str(r["updated_at"]),
             html=r["html"],
         )
         for r in rows
     ]
+
+
+@router.get("/documents/{doc_id}", response_model=DocumentDetail)
+async def get_document(doc_id: int, user: dict = Depends(require_session)):
+    db = get_db()
+    try:
+        row = db.execute(
+            "SELECT id, doc_type, title, created_at, updated_at, fields_json, html FROM documents WHERE id = ? AND user_id = ?",
+            (doc_id, user["id"]),
+        ).fetchone()
+    finally:
+        db.close()
+    if not row:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return DocumentDetail(
+        id=row["id"],
+        doc_type=row["doc_type"],
+        title=row["title"],
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+        html=row["html"],
+        fields=json.loads(row["fields_json"]),
+    )

--- a/backend/routers/generate.py
+++ b/backend/routers/generate.py
@@ -1,7 +1,11 @@
+from io import BytesIO
+
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, StreamingResponse
+from pydantic import BaseModel
 
 from models.nda import NdaRequest, NdaResponse
+from services.pdf import render_pdf
 from services.renderer import get_template_text, render_nda
 
 router = APIRouter(prefix="/api")
@@ -27,3 +31,21 @@ def generate_nda(data: NdaRequest) -> NdaResponse:
         return NdaResponse(html=html)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Rendering failed: {str(e)}")
+
+
+class PdfRequest(BaseModel):
+    html: str
+    filename: str = "document.pdf"
+
+
+@router.post("/pdf")
+async def generate_pdf(req: PdfRequest):
+    try:
+        pdf_bytes = await render_pdf(req.html)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"PDF generation failed: {str(e)}")
+    return StreamingResponse(
+        BytesIO(pdf_bytes),
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{req.filename}"'},
+    )

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -1,0 +1,51 @@
+import uuid
+
+import bcrypt
+from fastapi import Cookie, HTTPException
+
+from database import get_db
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    return bcrypt.checkpw(password.encode(), password_hash.encode())
+
+
+def create_session(user_id: int) -> str:
+    """Insert a new session row and return the token."""
+    token = uuid.uuid4().hex
+    db = get_db()
+    try:
+        db.execute("INSERT INTO sessions (id, user_id) VALUES (?, ?)", (token, user_id))
+        db.commit()
+    finally:
+        db.close()
+    return token
+
+
+def get_user_by_session(token: str) -> dict | None:
+    """Look up the user for a session token. Returns {id, email} or None."""
+    db = get_db()
+    try:
+        row = db.execute(
+            "SELECT u.id, u.email FROM users u JOIN sessions s ON u.id = s.user_id WHERE s.id = ?",
+            (token,),
+        ).fetchone()
+    finally:
+        db.close()
+    if row is None:
+        return None
+    return {"id": row["id"], "email": row["email"]}
+
+
+def require_session(session: str | None = Cookie(None)) -> dict:
+    """FastAPI dependency -- returns user dict or raises 401."""
+    if not session:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    user = get_user_by_session(session)
+    if not user:
+        raise HTTPException(status_code=401, detail="Session expired")
+    return user

--- a/backend/services/doc_renderer.py
+++ b/backend/services/doc_renderer.py
@@ -118,5 +118,9 @@ def render_generic_doc(
   <div class="standard-terms">
     {body_html}
   </div>
+  <footer style="margin-top:2in;padding-top:12px;border-top:1px solid #ccc;font-size:9pt;color:#666;font-style:italic;">
+    This document is an AI-generated draft for reference only and does not constitute legal advice.
+    It should be reviewed by a qualified attorney before use.
+  </footer>
 </body>
 </html>"""

--- a/backend/services/doc_renderer.py
+++ b/backend/services/doc_renderer.py
@@ -1,3 +1,4 @@
+import html
 import re
 
 import markdown as md_lib
@@ -29,11 +30,11 @@ def _replace_spans(text: str, fields: dict[str, str | None]) -> str:
         normalized = _normalize(match.group(1))
         value = fields.get(normalized)
         if value:
-            return value
+            return html.escape(value)
         if normalized.endswith("'s"):
             base_value = fields.get(normalized[:-2])
             if base_value:
-                return f"{base_value}'s"
+                return f"{html.escape(base_value)}'s"
         return f"[{normalized}]"
 
     return re.sub(
@@ -50,8 +51,8 @@ def _build_key_terms_section(fields: dict[str, str | None]) -> str:
         return ""
 
     rows = "".join(
-        f'<tr><td style="font-weight:bold;padding:6px 12px 6px 0;vertical-align:top;white-space:nowrap;">{k}</td>'
-        f'<td style="padding:6px 0;">{v}</td></tr>'
+        f'<tr><td style="font-weight:bold;padding:6px 12px 6px 0;vertical-align:top;white-space:nowrap;">{html.escape(k)}</td>'
+        f'<td style="padding:6px 0;">{html.escape(v)}</td></tr>'
         for k, v in filled.items()
     )
 
@@ -68,9 +69,13 @@ def render_generic_doc(
 ) -> str:
     """Render a generic legal document template to a printable HTML string."""
     template_md = get_template(doc_type)
-    doc_name = title or DOC_NAMES.get(doc_type, doc_type)
+    doc_name = html.escape(title or DOC_NAMES.get(doc_type, doc_type))
 
     text = _replace_spans(template_md, fields)
+
+    # Strip the leading markdown title (e.g. "# Cloud Service Agreement")
+    # since we add our own <h1> in the HTML wrapper
+    text = re.sub(r"^#\s+.+\n+", "", text, count=1)
 
     # Convert header spans into bold markdown so they render visibly
     text = re.sub(r'<span class="header_2"[^>]*>([^<]+)</span>', r'**\1**', text)
@@ -80,7 +85,7 @@ def render_generic_doc(
     for field_name, bracket in BRACKET_FIELDS.items():
         value = fields.get(field_name)
         if value:
-            text = text.replace(bracket, value)
+            text = text.replace(bracket, html.escape(value))
 
     body_html = md_lib.markdown(text, extensions=["tables"])
     key_terms_html = _build_key_terms_section(fields)

--- a/backend/services/pdf.py
+++ b/backend/services/pdf.py
@@ -1,0 +1,24 @@
+"""PDF generation via headless Chromium (Playwright).
+
+Renders a self-contained HTML document in Chromium and prints to PDF,
+producing output identical to what the browser displays.
+"""
+
+from playwright.async_api import async_playwright
+
+
+async def render_pdf(html: str) -> bytes:
+    """Render HTML to PDF bytes using headless Chromium."""
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        try:
+            page = await browser.new_page()
+            await page.set_content(html, wait_until="load")
+            pdf_bytes = await page.pdf(
+                format="Letter",
+                print_background=True,
+            )
+            await page.close()
+        finally:
+            await browser.close()
+    return pdf_bytes

--- a/backend/services/renderer.py
+++ b/backend/services/renderer.py
@@ -1,3 +1,4 @@
+import html as html_mod
 import re
 from datetime import datetime
 from pathlib import Path
@@ -52,10 +53,10 @@ def _build_signature_table(data: NdaRequest) -> str:
 
     rows = [
         ("Signature", sig1_html, sig2_html),
-        ("Print Name", data.party1.print_name, data.party2.print_name),
-        ("Title", data.party1.title, data.party2.title),
-        ("Company", data.party1.company, data.party2.company),
-        ("Notice Address", data.party1.notice_address, data.party2.notice_address),
+        ("Print Name", html_mod.escape(data.party1.print_name), html_mod.escape(data.party2.print_name)),
+        ("Title", html_mod.escape(data.party1.title), html_mod.escape(data.party2.title)),
+        ("Company", html_mod.escape(data.party1.company), html_mod.escape(data.party2.company)),
+        ("Notice Address", html_mod.escape(data.party1.notice_address), html_mod.escape(data.party2.notice_address)),
         ("Date", formatted_date1, formatted_date2),
     ]
 
@@ -84,7 +85,7 @@ def render_cover_page(data: NdaRequest, template_text: str) -> str:
     text = _safe_replace(
         text,
         "[Evaluating whether to enter into a business relationship with the other party.]",
-        data.purpose,
+        html_mod.escape(data.purpose),
     )
 
     # Effective Date
@@ -142,17 +143,17 @@ def render_cover_page(data: NdaRequest, template_text: str) -> str:
         )
 
     # Governing Law & Jurisdiction
-    text = _safe_replace(text, "[Fill in state]", data.governing_law_state)
+    text = _safe_replace(text, "[Fill in state]", html_mod.escape(data.governing_law_state))
     text = _safe_replace(
         text,
         '[Fill in city or county and state, i.e. "courts located in New Castle, DE"]',
-        data.jurisdiction,
+        html_mod.escape(data.jurisdiction),
     )
 
     # MNDA Modifications
     mods_section = "List any modifications to the MNDA"
     if data.modifications and data.modifications.strip():
-        text = _safe_replace(text, mods_section, data.modifications.strip())
+        text = _safe_replace(text, mods_section, html_mod.escape(data.modifications.strip()))
     else:
         text = _safe_replace(text, mods_section, "_No modifications._")
 
@@ -195,7 +196,8 @@ def render_standard_terms(data: NdaRequest, template_text: str) -> str:
 
     def replace_span(match: re.Match) -> str:
         field_name = match.group(1)
-        return field_map.get(field_name, field_name)
+        value = field_map.get(field_name, field_name)
+        return html_mod.escape(value)
 
     text = re.sub(
         r'<span class="coverpage_link">([^<]+)</span>',

--- a/backend/services/renderer.py
+++ b/backend/services/renderer.py
@@ -255,6 +255,10 @@ def render_nda(data: NdaRequest) -> str:
   <div class="standard-terms">
     {terms_html}
   </div>
+  <footer style="margin-top:2in;padding-top:12px;border-top:1px solid #ccc;font-size:9pt;color:#666;font-style:italic;">
+    This document is an AI-generated draft for reference only and does not constitute legal advice.
+    It should be reviewed by a qualified attorney before use.
+  </footer>
 </body>
 </html>"""
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 import copy
 import pytest
 from httpx import AsyncClient, ASGITransport
+from database import init_db
 from main import app
 
 VALID_PARTY = {
@@ -25,6 +26,12 @@ VALID_PAYLOAD = {
     "party1": VALID_PARTY,
     "party2": {**VALID_PARTY, "print_name": "Bob Jones", "company": "Widget Inc"},
 }
+
+
+@pytest.fixture(autouse=True)
+def fresh_db():
+    """Ensure every test starts with a clean database."""
+    init_db()
 
 
 @pytest.fixture

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,65 @@
+import pytest
+
+
+async def test_signup_creates_user(client):
+    r = await client.post("/api/auth/signup", json={"email": "a@b.com", "password": "password123"})
+    assert r.status_code == 200
+    assert r.json()["email"] == "a@b.com"
+    assert "session" in r.cookies
+
+
+async def test_signup_duplicate_email_returns_409(client):
+    await client.post("/api/auth/signup", json={"email": "dup@b.com", "password": "password123"})
+    r = await client.post("/api/auth/signup", json={"email": "dup@b.com", "password": "password123"})
+    assert r.status_code == 409
+
+
+async def test_signup_short_password_returns_422(client):
+    r = await client.post("/api/auth/signup", json={"email": "short@b.com", "password": "short"})
+    assert r.status_code == 422
+
+
+async def test_signin_valid(client):
+    await client.post("/api/auth/signup", json={"email": "login@b.com", "password": "password123"})
+    r = await client.post("/api/auth/signin", json={"email": "login@b.com", "password": "password123"})
+    assert r.status_code == 200
+    assert r.json()["email"] == "login@b.com"
+    assert "session" in r.cookies
+
+
+async def test_signin_wrong_password_returns_401(client):
+    await client.post("/api/auth/signup", json={"email": "wrong@b.com", "password": "password123"})
+    r = await client.post("/api/auth/signin", json={"email": "wrong@b.com", "password": "wrongpass1"})
+    assert r.status_code == 401
+
+
+async def test_signin_unknown_email_returns_401(client):
+    r = await client.post("/api/auth/signin", json={"email": "nope@b.com", "password": "password123"})
+    assert r.status_code == 401
+
+
+async def test_me_with_valid_session(client):
+    signup_r = await client.post("/api/auth/signup", json={"email": "me@b.com", "password": "password123"})
+    session_cookie = signup_r.cookies["session"]
+    client.cookies.set("session", session_cookie)
+    r = await client.get("/api/auth/me")
+    assert r.status_code == 200
+    assert r.json()["email"] == "me@b.com"
+
+
+async def test_me_without_session_returns_401(client):
+    r = await client.get("/api/auth/me")
+    assert r.status_code == 401
+
+
+async def test_signout_clears_session(client):
+    signup_r = await client.post("/api/auth/signup", json={"email": "out@b.com", "password": "password123"})
+    session_cookie = signup_r.cookies["session"]
+    client.cookies.set("session", session_cookie)
+    r = await client.post("/api/auth/signout")
+    assert r.status_code == 200
+    # Session should now be invalid
+    client.cookies.clear()
+    client.cookies.set("session", session_cookie)
+    r = await client.get("/api/auth/me")
+    assert r.status_code == 401

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,0 +1,51 @@
+import pytest
+
+
+async def _signup_and_auth(client, email="docs@b.com"):
+    """Helper: sign up and set the session cookie on the client."""
+    r = await client.post("/api/auth/signup", json={"email": email, "password": "password123"})
+    client.cookies.set("session", r.cookies["session"])
+    return r
+
+
+async def test_save_document_requires_auth(client):
+    r = await client.post("/api/documents", json={
+        "doc_type": "csa", "title": "Test CSA", "fields": {}, "html": "<p>test</p>",
+    })
+    assert r.status_code == 401
+
+
+async def test_save_and_list_documents(client):
+    await _signup_and_auth(client)
+    r = await client.post("/api/documents", json={
+        "doc_type": "csa", "title": "My CSA", "fields": {"Customer": "Acme"}, "html": "<p>csa</p>",
+    })
+    assert r.status_code == 201
+    assert "id" in r.json()
+
+    r = await client.get("/api/documents")
+    assert r.status_code == 200
+    docs = r.json()
+    assert len(docs) == 1
+    assert docs[0]["title"] == "My CSA"
+    assert docs[0]["doc_type"] == "csa"
+    assert docs[0]["html"] == "<p>csa</p>"
+
+
+async def test_documents_scoped_to_user(client):
+    await _signup_and_auth(client, "user1@b.com")
+    await client.post("/api/documents", json={
+        "doc_type": "csa", "title": "User1 Doc", "fields": {}, "html": "<p>1</p>",
+    })
+
+    # Sign up as a different user
+    client.cookies.clear()
+    await _signup_and_auth(client, "user2@b.com")
+    r = await client.get("/api/documents")
+    assert r.status_code == 200
+    assert len(r.json()) == 0
+
+
+async def test_list_documents_requires_auth(client):
+    r = await client.get("/api/documents")
+    assert r.status_code == 401

--- a/backend/tests/test_pdf.py
+++ b/backend/tests/test_pdf.py
@@ -1,0 +1,65 @@
+import asyncio
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from main import app
+from services.pdf import render_pdf
+
+
+@pytest.fixture
+def client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+async def test_render_pdf_basic():
+    pdf = await render_pdf("<h1>Hello</h1><p>World</p>")
+    assert pdf[:4] == b"%PDF"
+
+
+async def test_render_pdf_with_unicode():
+    html = "<p>Party\u2019s obligation under \u201cSection 1\u201d</p>"
+    pdf = await render_pdf(html)
+    assert pdf[:4] == b"%PDF"
+
+
+async def test_render_pdf_with_styles():
+    html = """<!DOCTYPE html><html><head>
+    <style>body { font-family: 'Times New Roman', serif; font-size: 11pt; }</style>
+    </head><body><h1>Styled</h1><p>Content</p></body></html>"""
+    pdf = await render_pdf(html)
+    assert pdf[:4] == b"%PDF"
+    assert len(pdf) > 1000  # styled doc should be nontrivial
+
+
+async def test_pdf_endpoint_returns_pdf(client):
+    resp = await client.post(
+        "/api/pdf",
+        json={"html": "<p>Hello world</p>", "filename": "test.pdf"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+    assert b"%PDF" in resp.content
+
+
+async def test_pdf_endpoint_handles_unicode(client):
+    resp = await client.post(
+        "/api/pdf",
+        json={"html": "<p>Party\u2019s obligation under \u201cSection 1\u201d</p>"},
+    )
+    assert resp.status_code == 200
+    assert b"%PDF" in resp.content
+
+
+async def test_pdf_endpoint_full_document(client):
+    html = """<!DOCTYPE html><html><head>
+    <style>body { font-family: serif; } table { border-collapse: collapse; }
+    td { border: 1px solid #000; padding: 8px; }</style>
+    </head><body>
+    <h1>Test Agreement</h1>
+    <table><tr><td>Party 1</td><td>Party 2</td></tr></table>
+    </body></html>"""
+    resp = await client.post("/api/pdf", json={"html": html})
+    assert resp.status_code == 200
+    assert b"%PDF" in resp.content

--- a/backend/tests/test_renderer.py
+++ b/backend/tests/test_renderer.py
@@ -124,15 +124,11 @@ def test_cover_with_modifications():
     assert "Add clause 5A" in html
 
 
-def test_cover_xss_passthrough():
-    """Backend does NOT HTML-escape user input — documents intentional behaviour.
-
-    The backend output goes directly to the browser's print renderer.
-    Escaping is the frontend's responsibility (templateRenderer.ts).
-    This test will fail (and should be fixed) if escaping is ever added here.
-    """
+def test_cover_xss_escaped():
+    """Backend HTML-escapes user input to prevent stored XSS."""
     html = render_cover_page(make_request(purpose="<script>alert(1)</script>"), MINIMAL_COVER)
-    assert "<script>" in html
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
 
 
 # --- render_standard_terms ---

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -319,6 +319,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -413,6 +422,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/56/6f389de21c49555553d6a5aeed5ac9767631497ac836c4f076273d15bd72/fonttools-4.62.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c22b1014017111c401469e3acc5433e6acf6ebcc6aa9efb538a533c800971c79", size = 2865155, upload-time = "2026-03-13T13:53:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c5/0e3966edd5ec668d41dfe418787726752bc07e2f5fd8c8f208615e61fa89/fonttools-4.62.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68959f5fc58ed4599b44aad161c2837477d7f35f5f79402d97439974faebfebe", size = 2412802, upload-time = "2026-03-13T13:53:18.878Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/e6ac4b44026de7786fe46e3bfa0c87e51d5d70a841054065d49cd62bb909/fonttools-4.62.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef46db46c9447103b8f3ff91e8ba009d5fe181b1920a83757a5762551e32bb68", size = 5013926, upload-time = "2026-03-13T13:53:21.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1", size = 4964575, upload-time = "2026-03-13T13:53:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/46/76/7d051671e938b1881670528fec69cc4044315edd71a229c7fd712eaa5119/fonttools-4.62.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e7abd2b1e11736f58c1de27819e1955a53267c21732e78243fa2fa2e5c1e069", size = 4953693, upload-time = "2026-03-13T13:53:26.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/b41f8628ec0be3c1b934fc12b84f4576a5c646119db4d3bdd76a217c90b5/fonttools-4.62.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:403d28ce06ebfc547fbcb0cb8b7f7cc2f7a2d3e1a67ba9a34b14632df9e080f9", size = 5094920, upload-time = "2026-03-13T13:53:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/53a1e9469331a23dcc400970a27a4caa3d9f6edbf5baab0260285238b884/fonttools-4.62.1-cp313-cp313-win32.whl", hash = "sha256:93c316e0f5301b2adbe6a5f658634307c096fd5aae60a5b3412e4f3e1728ab24", size = 2279928, upload-time = "2026-03-13T13:53:32.352Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/35186529de1db3c01f5ad625bde07c1f576305eab6d86bbda4c58445f721/fonttools-4.62.1-cp313-cp313-win_amd64.whl", hash = "sha256:7aa21ff53e28a9c2157acbc44e5b401149d3c9178107130e82d74ceb500e5056", size = 2330514, upload-time = "2026-03-13T13:53:34.991Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f0/2888cdac391807d68d90dcb16ef858ddc1b5309bfc6966195a459dd326e2/fonttools-4.62.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fa1d16210b6b10a826d71bed68dd9ec24a9e218d5a5e2797f37c573e7ec215ca", size = 2864442, upload-time = "2026-03-13T13:53:37.509Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b2/e521803081f8dc35990816b82da6360fa668a21b44da4b53fc9e77efcd62/fonttools-4.62.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aa69d10ed420d8121118e628ad47d86e4caa79ba37f968597b958f6cceab7eca", size = 2410901, upload-time = "2026-03-13T13:53:40.55Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/8c3511ff06e53110039358dbbdc1a65d72157a054638387aa2ada300a8b8/fonttools-4.62.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd13b7999d59c5eb1c2b442eb2d0c427cb517a0b7a1f5798fc5c9e003f5ff782", size = 4999608, upload-time = "2026-03-13T13:53:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/28/63/cd0c3b26afe60995a5295f37c246a93d454023726c3261cfbb3559969bb9/fonttools-4.62.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d337fdd49a79b0d51c4da87bc38169d21c3abbf0c1aa9367eff5c6656fb6dae", size = 4912726, upload-time = "2026-03-13T13:53:45.405Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b9/ac677cb07c24c685cf34f64e140617d58789d67a3dd524164b63648c6114/fonttools-4.62.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d241cdc4a67b5431c6d7f115fdf63335222414995e3a1df1a41e1182acd4bcc7", size = 4951422, upload-time = "2026-03-13T13:53:48.326Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/10/11c08419a14b85b7ca9a9faca321accccc8842dd9e0b1c8a72908de05945/fonttools-4.62.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c05557a78f8fa514da0f869556eeda40887a8abc77c76ee3f74cf241778afd5a", size = 5060979, upload-time = "2026-03-13T13:53:51.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3c/12eea4a4cf054e7ab058ed5ceada43b46809fce2bf319017c4d63ae55bb4/fonttools-4.62.1-cp314-cp314-win32.whl", hash = "sha256:49a445d2f544ce4a69338694cad575ba97b9a75fff02720da0882d1a73f12800", size = 2283733, upload-time = "2026-03-13T13:53:53.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/67/74b070029043186b5dd13462c958cb7c7f811be0d2e634309d9a1ffb1505/fonttools-4.62.1-cp314-cp314-win_amd64.whl", hash = "sha256:1eecc128c86c552fb963fe846ca4e011b1be053728f798185a1687502f6d398e", size = 2335663, upload-time = "2026-03-13T13:53:56.23Z" },
+    { url = "https://files.pythonhosted.org/packages/42/c5/4d2ed3ca6e33617fc5624467da353337f06e7f637707478903c785bd8e20/fonttools-4.62.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1596aeaddf7f78e21e68293c011316a25267b3effdaccaf4d59bc9159d681b82", size = 2947288, upload-time = "2026-03-13T13:53:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e9/7ab11ddfda48ed0f89b13380e5595ba572619c27077be0b2c447a63ff351/fonttools-4.62.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8f8fca95d3bb3208f59626a4b0ea6e526ee51f5a8ad5d91821c165903e8d9260", size = 2449023, upload-time = "2026-03-13T13:54:01.642Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/10/a800fa090b5e8819942e54e19b55fc7c21fe14a08757c3aa3ca8db358939/fonttools-4.62.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee91628c08e76f77b533d65feb3fbe6d9dad699f95be51cf0d022db94089cdc4", size = 5137599, upload-time = "2026-03-13T13:54:04.495Z" },
+    { url = "https://files.pythonhosted.org/packages/37/dc/8ccd45033fffd74deb6912fa1ca524643f584b94c87a16036855b498a1ed/fonttools-4.62.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f37df1cac61d906e7b836abe356bc2f34c99d4477467755c216b72aa3dc748b", size = 4920933, upload-time = "2026-03-13T13:54:07.557Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/e618adefb839598d25ac8136cd577925d6c513dc0d931d93b8af956210f0/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92bb00a947e666169c99b43753c4305fc95a890a60ef3aeb2a6963e07902cc87", size = 5016232, upload-time = "2026-03-13T13:54:10.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5f/9b5c9bfaa8ec82def8d8168c4f13615990d6ce5996fe52bd49bfb5e05134/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bdfe592802ef939a0e33106ea4a318eeb17822c7ee168c290273cbd5fabd746c", size = 5042987, upload-time = "2026-03-13T13:54:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/90/aa/dfbbe24c6a6afc5c203d90cc0343e24bcbb09e76d67c4d6eef8c2558d7ba/fonttools-4.62.1-cp314-cp314t-win32.whl", hash = "sha256:b820fcb92d4655513d8402d5b219f94481c4443d825b4372c75a2072aa4b357a", size = 2348021, upload-time = "2026-03-13T13:54:16.98Z" },
+    { url = "https://files.pythonhosted.org/packages/13/6f/ae9c4e4dd417948407b680855c2c7790efb52add6009aaecff1e3bc50e8e/fonttools-4.62.1-cp314-cp314t-win_amd64.whl", hash = "sha256:59b372b4f0e113d3746b88985f1c796e7bf830dd54b28374cd85c2b8acd7583e", size = 2414147, upload-time = "2026-03-13T13:54:19.416Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[[package]]
+name = "fpdf2"
+version = "2.8.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "fonttools" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/f2/72feae0b2827ed38013e4307b14f95bf0b3d124adfef4d38a7d57533f7be/fpdf2-2.8.7.tar.gz", hash = "sha256:7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9", size = 362351, upload-time = "2026-02-28T05:39:16.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/0a/cf50ecffa1e3747ed9380a3adfc829259f1f86b3fdbd9e505af789003141/fpdf2-2.8.7-py3-none-any.whl", hash = "sha256:d391fc508a3ce02fc43a577c830cda4fe6f37646f2d143d489839940932fbc19", size = 327056, upload-time = "2026-02-28T05:39:14.619Z" },
 ]
 
 [[package]]
@@ -511,6 +575,49 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
+    { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/cc802e067d02af8b60b6771cea7d57e21ef5e6659912814babb42b864713/greenlet-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f", size = 231081, upload-time = "2026-02-20T20:17:28.121Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2e/fe7f36ff1982d6b10a60d5e0740c759259a7d6d2e1dc41da6d96de32fff6/greenlet-3.3.2-cp312-cp312-win_arm64.whl", hash = "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643", size = 230331, upload-time = "2026-02-20T20:17:23.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
+    { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ca/2101ca3d9223a1dc125140dbc063644dca76df6ff356531eb27bc267b446/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492", size = 232034, upload-time = "2026-02-20T20:20:08.186Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/ecf894e962a59dea60f04877eea0fd5724618da89f1867b28ee8b91e811f/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71", size = 231437, upload-time = "2026-02-20T20:18:59.722Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
 ]
 
 [[package]]
@@ -1012,6 +1119,94 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload-time = "2026-02-11T04:23:07.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d3/8df65da0d4df36b094351dce696f2989bec731d4f10e743b1c5f4da4d3bf/pillow-12.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ab323b787d6e18b3d91a72fc99b1a2c28651e4358749842b8f8dfacd28ef2052", size = 5262803, upload-time = "2026-02-11T04:20:47.653Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/71/5026395b290ff404b836e636f51d7297e6c83beceaa87c592718747e670f/pillow-12.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:adebb5bee0f0af4909c30db0d890c773d1a92ffe83da908e2e9e720f8edf3984", size = 4657601, upload-time = "2026-02-11T04:20:49.328Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2e/1001613d941c67442f745aff0f7cc66dd8df9a9c084eb497e6a543ee6f7e/pillow-12.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb66b7cc26f50977108790e2456b7921e773f23db5630261102233eb355a3b79", size = 6234995, upload-time = "2026-02-11T04:20:51.032Z" },
+    { url = "https://files.pythonhosted.org/packages/07/26/246ab11455b2549b9233dbd44d358d033a2f780fa9007b61a913c5b2d24e/pillow-12.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aee2810642b2898bb187ced9b349e95d2a7272930796e022efaf12e99dccd293", size = 8045012, upload-time = "2026-02-11T04:20:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8b/07587069c27be7535ac1fe33874e32de118fbd34e2a73b7f83436a88368c/pillow-12.1.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0b1cd6232e2b618adcc54d9882e4e662a089d5768cd188f7c245b4c8c44a397", size = 6349638, upload-time = "2026-02-11T04:20:54.444Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/79/6df7b2ee763d619cda2fb4fea498e5f79d984dae304d45a8999b80d6cf5c/pillow-12.1.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7aac39bcf8d4770d089588a2e1dd111cbaa42df5a94be3114222057d68336bd0", size = 7041540, upload-time = "2026-02-11T04:20:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5e/2ba19e7e7236d7529f4d873bdaf317a318896bac289abebd4bb00ef247f0/pillow-12.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ab174cd7d29a62dd139c44bf74b698039328f45cb03b4596c43473a46656b2f3", size = 6462613, upload-time = "2026-02-11T04:20:57.542Z" },
+    { url = "https://files.pythonhosted.org/packages/03/03/31216ec124bb5c3dacd74ce8efff4cc7f52643653bad4825f8f08c697743/pillow-12.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:339ffdcb7cbeaa08221cd401d517d4b1fe7a9ed5d400e4a8039719238620ca35", size = 7166745, upload-time = "2026-02-11T04:20:59.196Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e7/7c4552d80052337eb28653b617eafdef39adfb137c49dd7e831b8dc13bc5/pillow-12.1.1-cp312-cp312-win32.whl", hash = "sha256:5d1f9575a12bed9e9eedd9a4972834b08c97a352bd17955ccdebfeca5913fa0a", size = 6328823, upload-time = "2026-02-11T04:21:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/17/688626d192d7261bbbf98846fc98995726bddc2c945344b65bec3a29d731/pillow-12.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:21329ec8c96c6e979cd0dfd29406c40c1d52521a90544463057d2aaa937d66a6", size = 7033367, upload-time = "2026-02-11T04:21:03.536Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/fe/a0ef1f73f939b0eca03ee2c108d0043a87468664770612602c63266a43c4/pillow-12.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:af9a332e572978f0218686636610555ae3defd1633597be015ed50289a03c523", size = 2453811, upload-time = "2026-02-11T04:21:05.116Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/11/6db24d4bd7685583caeae54b7009584e38da3c3d4488ed4cd25b439de486/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e", size = 4062689, upload-time = "2026-02-11T04:21:06.804Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c0/ce6d3b1fe190f0021203e0d9b5b99e57843e345f15f9ef22fcd43842fd21/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9", size = 4138535, upload-time = "2026-02-11T04:21:08.452Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c6/d5eb6a4fb32a3f9c21a8c7613ec706534ea1cf9f4b3663e99f0d83f6fca8/pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6", size = 3601364, upload-time = "2026-02-11T04:21:10.194Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a1/16c4b823838ba4c9c52c0e6bbda903a3fe5a1bdbf1b8eb4fff7156f3e318/pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60", size = 5262561, upload-time = "2026-02-11T04:21:11.742Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ad/ad9dc98ff24f485008aa5cdedaf1a219876f6f6c42a4626c08bc4e80b120/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2", size = 4657460, upload-time = "2026-02-11T04:21:13.786Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f1a4ea9a895b5732152789326202a82464d5254759fbacae4deea3069334/pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850", size = 6232698, upload-time = "2026-02-11T04:21:15.949Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/86f51b8745070daf21fd2e5b1fe0eb35d4db9ca26e6d58366562fb56a743/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289", size = 8041706, upload-time = "2026-02-11T04:21:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9b/d6ecd956bb1266dd1045e995cce9b8d77759e740953a1c9aad9502a0461e/pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e", size = 6346621, upload-time = "2026-02-11T04:21:19.547Z" },
+    { url = "https://files.pythonhosted.org/packages/71/24/538bff45bde96535d7d998c6fed1a751c75ac7c53c37c90dc2601b243893/pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717", size = 7038069, upload-time = "2026-02-11T04:21:21.378Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0e/58cb1a6bc48f746bc4cb3adb8cabff73e2742c92b3bf7a220b7cf69b9177/pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a", size = 6460040, upload-time = "2026-02-11T04:21:23.148Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/57/9045cb3ff11eeb6c1adce3b2d60d7d299d7b273a2e6c8381a524abfdc474/pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029", size = 7164523, upload-time = "2026-02-11T04:21:25.01Z" },
+    { url = "https://files.pythonhosted.org/packages/73/f2/9be9cb99f2175f0d4dbadd6616ce1bf068ee54a28277ea1bf1fbf729c250/pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b", size = 6332552, upload-time = "2026-02-11T04:21:27.238Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1", size = 7040108, upload-time = "2026-02-11T04:21:29.462Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/fc09634e2aabdd0feabaff4a32f4a7d97789223e7c2042fd805ea4b4d2c2/pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a", size = 2453712, upload-time = "2026-02-11T04:21:31.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/b9d62794fc8a0dd14c1943df68347badbd5511103e0d04c035ffe5cf2255/pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da", size = 5264880, upload-time = "2026-02-11T04:21:32.865Z" },
+    { url = "https://files.pythonhosted.org/packages/26/9d/e03d857d1347fa5ed9247e123fcd2a97b6220e15e9cb73ca0a8d91702c6e/pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc", size = 4660616, upload-time = "2026-02-11T04:21:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ec/8a6d22afd02570d30954e043f09c32772bfe143ba9285e2fdb11284952cd/pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c", size = 6269008, upload-time = "2026-02-11T04:21:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/1d/6d875422c9f28a4a361f495a5f68d9de4a66941dc2c619103ca335fa6446/pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8", size = 8073226, upload-time = "2026-02-11T04:21:38.585Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/cd/134b0b6ee5eda6dc09e25e24b40fdafe11a520bc725c1d0bbaa5e00bf95b/pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20", size = 6380136, upload-time = "2026-02-11T04:21:40.562Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a9/7628f013f18f001c1b98d8fffe3452f306a70dc6aba7d931019e0492f45e/pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13", size = 7067129, upload-time = "2026-02-11T04:21:42.521Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f8/66ab30a2193b277785601e82ee2d49f68ea575d9637e5e234faaa98efa4c/pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf", size = 6491807, upload-time = "2026-02-11T04:21:44.22Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0b/a877a6627dc8318fdb84e357c5e1a758c0941ab1ddffdafd231983788579/pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524", size = 7190954, upload-time = "2026-02-11T04:21:46.114Z" },
+    { url = "https://files.pythonhosted.org/packages/83/43/6f732ff85743cf746b1361b91665d9f5155e1483817f693f8d57ea93147f/pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986", size = 6336441, upload-time = "2026-02-11T04:21:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/44/e865ef3986611bb75bfabdf94a590016ea327833f434558801122979cd0e/pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c", size = 7045383, upload-time = "2026-02-11T04:21:50.015Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/c6/f4fb24268d0c6908b9f04143697ea18b0379490cb74ba9e8d41b898bd005/pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3", size = 2456104, upload-time = "2026-02-11T04:21:51.633Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/bebb3ffbf31c5a8e97241476c4cf8b9828954693ce6744b4a2326af3e16b/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:417423db963cb4be8bac3fc1204fe61610f6abeed1580a7a2cbb2fbda20f12af", size = 4062652, upload-time = "2026-02-11T04:21:53.19Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c0/0e16fb0addda4851445c28f8350d8c512f09de27bbb0d6d0bbf8b6709605/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b957b71c6b2387610f556a7eb0828afbe40b4a98036fc0d2acfa5a44a0c2036f", size = 4138823, upload-time = "2026-02-11T04:22:03.088Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/fb/6170ec655d6f6bb6630a013dd7cf7bc218423d7b5fa9071bf63dc32175ae/pillow-12.1.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:097690ba1f2efdeb165a20469d59d8bb03c55fb6621eb2041a060ae8ea3e9642", size = 3601143, upload-time = "2026-02-11T04:22:04.909Z" },
+    { url = "https://files.pythonhosted.org/packages/59/04/dc5c3f297510ba9a6837cbb318b87dd2b8f73eb41a43cc63767f65cb599c/pillow-12.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2815a87ab27848db0321fb78c7f0b2c8649dee134b7f2b80c6a45c6831d75ccd", size = 5266254, upload-time = "2026-02-11T04:22:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/05/30/5db1236b0d6313f03ebf97f5e17cda9ca060f524b2fcc875149a8360b21c/pillow-12.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f7ed2c6543bad5a7d5530eb9e78c53132f93dfa44a28492db88b41cdab885202", size = 4657499, upload-time = "2026-02-11T04:22:09.613Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/008d2ca0eb612e81968e8be0bbae5051efba24d52debf930126d7eaacbba/pillow-12.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:652a2c9ccfb556235b2b501a3a7cf3742148cd22e04b5625c5fe057ea3e3191f", size = 6232137, upload-time = "2026-02-11T04:22:11.434Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f1/f14d5b8eeb4b2cd62b9f9f847eb6605f103df89ef619ac68f92f748614ea/pillow-12.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6e4571eedf43af33d0fc233a382a76e849badbccdf1ac438841308652a08e1f", size = 8042721, upload-time = "2026-02-11T04:22:13.321Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/d6/17824509146e4babbdabf04d8171491fa9d776f7061ff6e727522df9bd03/pillow-12.1.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b574c51cf7d5d62e9be37ba446224b59a2da26dc4c1bb2ecbe936a4fb1a7cb7f", size = 6347798, upload-time = "2026-02-11T04:22:15.449Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/ee/c85a38a9ab92037a75615aba572c85ea51e605265036e00c5b67dfafbfe2/pillow-12.1.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a37691702ed687799de29a518d63d4682d9016932db66d4e90c345831b02fb4e", size = 7039315, upload-time = "2026-02-11T04:22:17.24Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f3/bc8ccc6e08a148290d7523bde4d9a0d6c981db34631390dc6e6ec34cacf6/pillow-12.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f95c00d5d6700b2b890479664a06e754974848afaae5e21beb4d83c106923fd0", size = 6462360, upload-time = "2026-02-11T04:22:19.111Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ab/69a42656adb1d0665ab051eec58a41f169ad295cf81ad45406963105408f/pillow-12.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:559b38da23606e68681337ad74622c4dbba02254fc9cb4488a305dd5975c7eeb", size = 7165438, upload-time = "2026-02-11T04:22:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/02/46/81f7aa8941873f0f01d4b55cc543b0a3d03ec2ee30d617a0448bf6bd6dec/pillow-12.1.1-cp314-cp314-win32.whl", hash = "sha256:03edcc34d688572014ff223c125a3f77fb08091e4607e7745002fc214070b35f", size = 6431503, upload-time = "2026-02-11T04:22:22.833Z" },
+    { url = "https://files.pythonhosted.org/packages/40/72/4c245f7d1044b67affc7f134a09ea619d4895333d35322b775b928180044/pillow-12.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:50480dcd74fa63b8e78235957d302d98d98d82ccbfac4c7e12108ba9ecbdba15", size = 7176748, upload-time = "2026-02-11T04:22:24.64Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ad/8a87bdbe038c5c698736e3348af5c2194ffb872ea52f11894c95f9305435/pillow-12.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:5cb1785d97b0c3d1d1a16bc1d710c4a0049daefc4935f3a8f31f827f4d3d2e7f", size = 2544314, upload-time = "2026-02-11T04:22:26.685Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9d/efd18493f9de13b87ede7c47e69184b9e859e4427225ea962e32e56a49bc/pillow-12.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1f90cff8aa76835cba5769f0b3121a22bd4eb9e6884cfe338216e557a9a548b8", size = 5268612, upload-time = "2026-02-11T04:22:29.884Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/4f42eb2b388eb2ffc660dcb7f7b556c1015c53ebd5f7f754965ef997585b/pillow-12.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f1be78ce9466a7ee64bfda57bdba0f7cc499d9794d518b854816c41bf0aa4e9", size = 4660567, upload-time = "2026-02-11T04:22:31.799Z" },
+    { url = "https://files.pythonhosted.org/packages/01/54/df6ef130fa43e4b82e32624a7b821a2be1c5653a5fdad8469687a7db4e00/pillow-12.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:42fc1f4677106188ad9a55562bbade416f8b55456f522430fadab3cef7cd4e60", size = 6269951, upload-time = "2026-02-11T04:22:33.921Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/48/618752d06cc44bb4aae8ce0cd4e6426871929ed7b46215638088270d9b34/pillow-12.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98edb152429ab62a1818039744d8fbb3ccab98a7c29fc3d5fcef158f3f1f68b7", size = 8074769, upload-time = "2026-02-11T04:22:35.877Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bd/f1d71eb39a72fa088d938655afba3e00b38018d052752f435838961127d8/pillow-12.1.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d470ab1178551dd17fdba0fef463359c41aaa613cdcd7ff8373f54be629f9f8f", size = 6381358, upload-time = "2026-02-11T04:22:37.698Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ef/c784e20b96674ed36a5af839305f55616f8b4f8aa8eeccf8531a6e312243/pillow-12.1.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6408a7b064595afcab0a49393a413732a35788f2a5092fdc6266952ed67de586", size = 7068558, upload-time = "2026-02-11T04:22:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cb/8059688b74422ae61278202c4e1ad992e8a2e7375227be0a21c6b87ca8d5/pillow-12.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5d8c41325b382c07799a3682c1c258469ea2ff97103c53717b7893862d0c98ce", size = 6493028, upload-time = "2026-02-11T04:22:42.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/da/e3c008ed7d2dd1f905b15949325934510b9d1931e5df999bb15972756818/pillow-12.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7697918b5be27424e9ce568193efd13d925c4481dd364e43f5dff72d33e10f8", size = 7191940, upload-time = "2026-02-11T04:22:44.543Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,8 +1222,10 @@ source = { virtual = "." }
 dependencies = [
     { name = "bcrypt" },
     { name = "fastapi" },
+    { name = "fpdf2" },
     { name = "litellm" },
     { name = "markdown" },
+    { name = "playwright" },
     { name = "pydantic", extra = ["email"] },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -1046,8 +1243,10 @@ dev = [
 requires-dist = [
     { name = "bcrypt", specifier = ">=5.0.0" },
     { name = "fastapi", specifier = ">=0.111.0" },
+    { name = "fpdf2", specifier = ">=2.8.7" },
     { name = "litellm", specifier = ">=1.82.6" },
     { name = "markdown", specifier = ">=3.6" },
+    { name = "playwright", specifier = ">=1.52.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.7.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.9" },
@@ -1234,6 +1433,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
     { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
     { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -150,6 +150,72 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -259,6 +325,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -937,10 +1025,11 @@ name = "prelegal-backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "bcrypt" },
     { name = "fastapi" },
     { name = "litellm" },
     { name = "markdown" },
-    { name = "pydantic" },
+    { name = "pydantic", extra = ["email"] },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
@@ -955,10 +1044,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bcrypt", specifier = ">=5.0.0" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "litellm", specifier = ">=1.82.6" },
     { name = "markdown", specifier = ">=3.6" },
-    { name = "pydantic", specifier = ">=2.7.1" },
+    { name = "pydantic", extras = ["email"], specifier = ">=2.7.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29.0" },
@@ -1068,6 +1158,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]

--- a/frontend/src/app/doc/[slug]/DocChatClient.tsx
+++ b/frontend/src/app/doc/[slug]/DocChatClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import Link from "next/link";
 import {
   DocChatMessage,
   fetchDocTemplate,
@@ -10,6 +9,10 @@ import {
 } from "@/lib/docChatApi";
 import { renderGenericTemplate } from "@/lib/genericRenderer";
 import { ChatPanel } from "@/components/chat/ChatPanel";
+import { NavBar } from "@/components/NavBar";
+import { useAuth } from "@/lib/auth";
+import { saveDocument } from "@/lib/documentsApi";
+import { DISCLAIMER } from "@/lib/disclaimer";
 import { printDocument } from "@/lib/printDocument";
 
 const DOC_NAMES: Record<string, string> = {
@@ -31,6 +34,7 @@ interface Props {
 }
 
 export function DocChatClient({ slug }: Props) {
+  const { user, loading: authLoading } = useAuth();
   const docName = DOC_NAMES[slug] ?? slug;
 
   const [messages, setMessages] = useState<DocChatMessage[]>([]);
@@ -40,14 +44,12 @@ export function DocChatClient({ slug }: Props) {
   const [templateMd, setTemplateMd] = useState<string>("");
   const [isGenerating, setIsGenerating] = useState(false);
 
-  // Load template for live preview
   useEffect(() => {
     fetchDocTemplate(slug)
       .then(setTemplateMd)
       .catch(() => {});
   }, [slug]);
 
-  // Greet user on mount
   useEffect(() => {
     async function greet() {
       setIsLoading(true);
@@ -95,6 +97,8 @@ export function DocChatClient({ slug }: Props) {
     setIsGenerating(true);
     try {
       const { html } = await generateDoc(slug, currentFields, docName);
+      saveDocument({ doc_type: slug, title: docName, fields: currentFields, html })
+        .catch(() => {});
       printDocument(html);
     } catch {
       setChatError("Failed to generate document. Please try again.");
@@ -103,24 +107,34 @@ export function DocChatClient({ slug }: Props) {
     }
   }
 
+  if (authLoading || !user) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-brand-gray text-sm">Loading...</p>
+      </div>
+    );
+  }
+
   return (
     <div className="h-screen flex flex-col">
-      {/* Header */}
-      <header className="bg-brand-navy text-white px-6 py-3 flex items-center justify-between shrink-0">
-        <div>
-          <Link href="/" className="text-xs text-brand-gray hover:text-white mr-3">
-            ← Back
-          </Link>
-          <span className="font-semibold text-sm">{docName}</span>
-        </div>
-        <button
-          onClick={handleDownload}
-          disabled={isGenerating}
-          className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90 disabled:opacity-50"
-        >
-          {isGenerating ? "Generating..." : "Download PDF"}
-        </button>
-      </header>
+      <NavBar
+        title={docName}
+        backHref="/"
+        rightSlot={
+          <button
+            onClick={handleDownload}
+            disabled={isGenerating}
+            className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90 disabled:opacity-50"
+          >
+            {isGenerating ? "Generating..." : "Download PDF"}
+          </button>
+        }
+      />
+
+      {/* Disclaimer banner */}
+      <div className="bg-amber-50 border-b border-amber-200 px-6 py-1.5 text-xs text-amber-700 shrink-0">
+        {DISCLAIMER}
+      </div>
 
       {/* Main split pane */}
       <div className="flex flex-1 overflow-hidden">

--- a/frontend/src/app/doc/[slug]/DocChatClient.tsx
+++ b/frontend/src/app/doc/[slug]/DocChatClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   DocChatMessage,
   fetchDocTemplate,
@@ -11,7 +12,7 @@ import { renderGenericTemplate } from "@/lib/genericRenderer";
 import { ChatPanel } from "@/components/chat/ChatPanel";
 import { NavBar } from "@/components/NavBar";
 import { useAuth } from "@/lib/auth";
-import { saveDocument } from "@/lib/documentsApi";
+import { saveDocument, getDocument } from "@/lib/documentsApi";
 import { DISCLAIMER } from "@/lib/disclaimer";
 import { printDocument } from "@/lib/printDocument";
 
@@ -35,6 +36,7 @@ interface Props {
 
 export function DocChatClient({ slug }: Props) {
   const { user, loading: authLoading } = useAuth();
+  const searchParams = useSearchParams();
   const docName = DOC_NAMES[slug] ?? slug;
 
   const [messages, setMessages] = useState<DocChatMessage[]>([]);
@@ -42,28 +44,47 @@ export function DocChatClient({ slug }: Props) {
   const [isLoading, setIsLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
   const [templateMd, setTemplateMd] = useState<string>("");
+  const [templateError, setTemplateError] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [mobileTab, setMobileTab] = useState<"chat" | "preview">("chat");
 
-  useEffect(() => {
+  function loadTemplate() {
+    setTemplateError(false);
     fetchDocTemplate(slug)
       .then(setTemplateMd)
-      .catch(() => {});
-  }, [slug]);
+      .catch(() => setTemplateError(true));
+  }
 
   useEffect(() => {
-    async function greet() {
+    loadTemplate();
+  }, [slug]);
+
+  // Resume from saved document or greet on mount
+  useEffect(() => {
+    const resumeId = searchParams.get("resume");
+    if (resumeId) {
+      getDocument(Number(resumeId))
+        .then((doc) => {
+          setCurrentFields(doc.fields as Record<string, string | null>);
+          setMessages([{ role: "assistant", content: "Welcome back! Your saved document has been loaded. Continue chatting to make changes." }]);
+        })
+        .catch(() => {
+          setChatError("Failed to load saved document. Starting fresh.");
+        });
+    } else {
       setIsLoading(true);
-      try {
-        const res = await sendDocChatMessage(slug, [], {});
-        setMessages([{ role: "assistant", content: res.reply }]);
-        setCurrentFields(res.fields);
-      } catch {
-        setChatError("Failed to connect to the AI. Please refresh and try again.");
-      } finally {
-        setIsLoading(false);
-      }
+      sendDocChatMessage(slug, [], {})
+        .then((res) => {
+          setMessages([{ role: "assistant", content: res.reply }]);
+          setCurrentFields(res.fields);
+        })
+        .catch(() => {
+          setChatError("Failed to connect to the AI. Please refresh and try again.");
+        })
+        .finally(() => setIsLoading(false));
     }
-    greet();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slug]);
 
@@ -93,13 +114,24 @@ export function DocChatClient({ slug }: Props) {
     return renderGenericTemplate(templateMd, currentFields);
   }, [templateMd, currentFields]);
 
+  function handleSave() {
+    setIsSaving(true);
+    saveDocument({ doc_type: slug, title: docName, fields: currentFields, html: previewHtml })
+      .then(() => {
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+      })
+      .catch(() => setChatError("Failed to save document."))
+      .finally(() => setIsSaving(false));
+  }
+
   async function handleDownload() {
     setIsGenerating(true);
     try {
       const { html } = await generateDoc(slug, currentFields, docName);
       saveDocument({ doc_type: slug, title: docName, fields: currentFields, html })
         .catch(() => {});
-      printDocument(html);
+      await printDocument(html);
     } catch {
       setChatError("Failed to generate document. Please try again.");
     } finally {
@@ -121,13 +153,22 @@ export function DocChatClient({ slug }: Props) {
         title={docName}
         backHref="/"
         rightSlot={
-          <button
-            onClick={handleDownload}
-            disabled={isGenerating}
-            className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90 disabled:opacity-50"
-          >
-            {isGenerating ? "Generating..." : "Download PDF"}
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleSave}
+              disabled={isSaving}
+              className="bg-brand-blue text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90 disabled:opacity-50"
+            >
+              {saved ? "Saved" : isSaving ? "Saving..." : "Save"}
+            </button>
+            <button
+              onClick={handleDownload}
+              disabled={isGenerating}
+              className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90 disabled:opacity-50"
+            >
+              {isGenerating ? "Generating..." : "Download PDF"}
+            </button>
+          </div>
         }
       />
 
@@ -136,11 +177,27 @@ export function DocChatClient({ slug }: Props) {
         {DISCLAIMER}
       </div>
 
+      {/* Mobile tab toggle */}
+      <div className="flex md:hidden border-b border-gray-200 shrink-0">
+        <button
+          onClick={() => setMobileTab("chat")}
+          className={`flex-1 py-2 text-xs font-semibold text-center ${mobileTab === "chat" ? "text-brand-blue border-b-2 border-brand-blue" : "text-brand-gray"}`}
+        >
+          Chat
+        </button>
+        <button
+          onClick={() => setMobileTab("preview")}
+          className={`flex-1 py-2 text-xs font-semibold text-center ${mobileTab === "preview" ? "text-brand-blue border-b-2 border-brand-blue" : "text-brand-gray"}`}
+        >
+          Preview
+        </button>
+      </div>
+
       {/* Main split pane */}
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
         {/* Left: Chat */}
-        <div className="w-2/5 flex flex-col border-r border-gray-200 bg-white">
-          <div className="px-4 py-3 border-b border-gray-100 shrink-0">
+        <div className={`${mobileTab === "chat" ? "flex" : "hidden"} md:flex w-full md:w-2/5 flex-col border-r border-gray-200 bg-white flex-1 md:flex-initial`}>
+          <div className="px-4 py-3 border-b border-gray-100 shrink-0 hidden md:block">
             <p className="text-xs font-medium text-brand-navy">AI Assistant</p>
             <p className="text-xs text-brand-gray">Answers update the document preview live</p>
           </div>
@@ -156,15 +213,25 @@ export function DocChatClient({ slug }: Props) {
         </div>
 
         {/* Right: Document preview */}
-        <div className="flex-1 flex flex-col bg-gray-50 overflow-hidden">
-          <div className="px-6 py-3 border-b border-gray-200 shrink-0">
+        <div className={`${mobileTab === "preview" ? "flex" : "hidden"} md:flex flex-1 flex-col bg-gray-50 overflow-hidden`}>
+          <div className="px-6 py-3 border-b border-gray-200 shrink-0 hidden md:block">
             <p className="text-xs font-medium text-brand-navy">Document Preview</p>
             <p className="text-xs text-brand-gray">Updates as you chat</p>
           </div>
-          <div className="flex-1 overflow-auto p-6">
-            {previewHtml ? (
+          <div className="flex-1 overflow-auto p-4 md:p-6">
+            {templateError ? (
+              <div className="flex flex-col items-center justify-center h-full gap-3">
+                <p className="text-red-600 text-sm">Failed to load document template.</p>
+                <button
+                  onClick={loadTemplate}
+                  className="bg-brand-blue text-white px-4 py-2 rounded-lg text-sm font-semibold hover:opacity-90"
+                >
+                  Retry
+                </button>
+              </div>
+            ) : previewHtml ? (
               <div
-                className="bg-white rounded-lg shadow-sm p-8 doc-content"
+                className="bg-white rounded-lg shadow-sm p-4 md:p-8 doc-content"
                 dangerouslySetInnerHTML={{ __html: previewHtml }}
               />
             ) : (

--- a/frontend/src/app/doc/[slug]/page.tsx
+++ b/frontend/src/app/doc/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { DocChatClient } from "./DocChatClient";
 
 const SLUGS = [
@@ -19,5 +20,13 @@ export function generateStaticParams() {
 }
 
 export default function DocPage({ params }: { params: { slug: string } }) {
-  return <DocChatClient slug={params.slug} />;
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-brand-gray text-sm">Loading...</p>
+      </div>
+    }>
+      <DocChatClient slug={params.slug} />
+    </Suspense>
+  );
 }

--- a/frontend/src/app/documents/page.tsx
+++ b/frontend/src/app/documents/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { DocumentRecord, getDocuments } from "@/lib/documentsApi";
+import { printDocument } from "@/lib/printDocument";
+import { NavBar } from "@/components/NavBar";
+import { useAuth } from "@/lib/auth";
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function resumeHref(doc: DocumentRecord): string {
+  if (doc.doc_type === "mutual-nda") return `/nda?resume=${doc.id}`;
+  return `/doc/${doc.doc_type}?resume=${doc.id}`;
+}
+
+export default function DocumentsPage() {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const [docs, setDocs] = useState<DocumentRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [previewDoc, setPreviewDoc] = useState<DocumentRecord | null>(null);
+
+  function fetchDocs() {
+    if (!user) return;
+    setLoading(true);
+    setError(false);
+    getDocuments()
+      .then(setDocs)
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    fetchDocs();
+  }, [user]);
+
+  if (authLoading || !user) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-brand-gray text-sm">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <NavBar title="My Documents" backHref="/" />
+
+      <main className="flex-1 max-w-5xl mx-auto px-6 py-12 w-full">
+        <h1 className="text-3xl font-bold text-brand-navy mb-2">My Documents</h1>
+        <p className="text-brand-gray mb-8">
+          View, resume editing, or download your saved documents.
+        </p>
+
+        {loading ? (
+          <p className="text-brand-gray text-sm">Loading your documents...</p>
+        ) : error ? (
+          <div className="text-center py-16">
+            <p className="text-red-600 text-sm mb-3">Failed to load your documents.</p>
+            <button
+              onClick={fetchDocs}
+              className="bg-brand-blue text-white px-4 py-2 rounded-lg text-sm font-semibold hover:opacity-90"
+            >
+              Retry
+            </button>
+          </div>
+        ) : docs.length === 0 ? (
+          <div className="text-center py-16">
+            <p className="text-brand-gray mb-4">You have no saved documents yet.</p>
+            <button
+              onClick={() => router.push("/")}
+              className="bg-brand-purple text-white px-6 py-2 rounded-lg text-sm font-semibold hover:opacity-90"
+            >
+              Create a document
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {docs.map((doc) => (
+              <div
+                key={doc.id}
+                className="bg-white rounded-lg border border-gray-200 p-5 hover:border-brand-blue hover:shadow-md transition"
+              >
+                <h3 className="font-semibold text-brand-navy mb-1 text-sm">
+                  {doc.title}
+                </h3>
+                <p className="text-xs text-brand-gray mb-4">
+                  {formatDate(doc.updated_at)}
+                </p>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => router.push(resumeHref(doc))}
+                    className="bg-brand-blue text-white px-3 py-1 rounded text-xs font-semibold hover:opacity-90"
+                  >
+                    Resume editing
+                  </button>
+                  <button
+                    onClick={() => setPreviewDoc(doc)}
+                    className="border border-gray-300 text-brand-navy px-3 py-1 rounded text-xs font-semibold hover:bg-gray-50"
+                  >
+                    Preview
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+
+      {previewDoc && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col">
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+              <h3 className="font-semibold text-brand-navy">
+                {previewDoc.title}
+              </h3>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => {
+                    router.push(resumeHref(previewDoc));
+                    setPreviewDoc(null);
+                  }}
+                  className="bg-brand-blue text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90"
+                >
+                  Resume editing
+                </button>
+                <button
+                  onClick={() => printDocument(previewDoc.html)}
+                  className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90"
+                >
+                  Download PDF
+                </button>
+                <button
+                  onClick={() => setPreviewDoc(null)}
+                  className="text-brand-gray hover:text-brand-navy text-sm"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+            <div className="flex-1 overflow-auto p-6">
+              <div
+                className="doc-content"
+                dangerouslySetInnerHTML={{ __html: previewDoc.html }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -14,8 +14,8 @@ const geistMono = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "Mutual NDA Creator | Prelegal",
-  description: "Create a Mutual Non-Disclosure Agreement based on Common Paper MNDA Version 1.0",
+  title: "Prelegal - AI-Assisted Legal Document Drafting",
+  description: "Draft legal agreements with AI assistance. Professional templates for NDAs, service agreements, and more.",
 };
 
 export default function RootLayout({

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,30 +2,51 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { setAuthCache } from "@/lib/auth";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001";
 
 export default function LoginPage() {
   const router = useRouter();
+  const [tab, setTab] = useState<"signin" | "signup">("signin");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    setError(null);
+
+    if (tab === "signup" && password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+
     setLoading(true);
     try {
-      await fetch(`${API_BASE}/api/auth/signin`, {
+      const endpoint = tab === "signup" ? "/api/auth/signup" : "/api/auth/signin";
+      const res = await fetch(`${API_BASE}${endpoint}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ email, password }),
       });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setError(data?.detail ?? "Something went wrong. Please try again.");
+        return;
+      }
+
+      const data = await res.json();
+      setAuthCache({ email: data.email });
+      router.push("/");
     } catch {
-      // ignore — fake login always proceeds
+      setError("Unable to connect to the server. Please try again.");
     } finally {
       setLoading(false);
     }
-    router.push("/");
   }
 
   return (
@@ -37,55 +58,101 @@ export default function LoginPage() {
         </p>
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 w-full max-w-sm p-8">
-        <h2 className="text-lg font-semibold text-brand-navy mb-6">Sign in</h2>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-brand-navy mb-1"
-            >
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              required
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue"
-              placeholder="you@example.com"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor="password"
-              className="block text-sm font-medium text-brand-navy mb-1"
-            >
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              required
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue"
-              placeholder="••••••••"
-            />
-          </div>
-
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 w-full max-w-sm">
+        {/* Tabs */}
+        <div className="flex border-b border-gray-200">
           <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-brand-purple text-white rounded-lg py-2 text-sm font-semibold hover:opacity-90 transition disabled:opacity-50 mt-2"
+            onClick={() => { setTab("signin"); setError(null); }}
+            className={`flex-1 py-3 text-sm font-medium transition-colors ${
+              tab === "signin"
+                ? "text-brand-navy border-b-2 border-brand-blue"
+                : "text-brand-gray hover:text-brand-navy"
+            }`}
           >
-            {loading ? "Signing in..." : "Sign in"}
+            Sign in
           </button>
-        </form>
+          <button
+            onClick={() => { setTab("signup"); setError(null); }}
+            className={`flex-1 py-3 text-sm font-medium transition-colors ${
+              tab === "signup"
+                ? "text-brand-navy border-b-2 border-brand-blue"
+                : "text-brand-gray hover:text-brand-navy"
+            }`}
+          >
+            Sign up
+          </button>
+        </div>
+
+        <div className="p-8">
+          {error && (
+            <div className="mb-4 px-3 py-2 rounded-lg bg-red-50 text-red-600 text-xs border border-red-100">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-brand-navy mb-1"
+              >
+                Email
+              </label>
+              <input
+                id="email"
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue"
+                placeholder="you@example.com"
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor="password"
+                className="block text-sm font-medium text-brand-navy mb-1"
+              >
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-blue"
+                placeholder="••••••••"
+              />
+              {tab === "signup" && (
+                <p className="text-xs text-brand-gray mt-1">
+                  Must be at least 8 characters
+                </p>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-brand-purple text-white rounded-lg py-2 text-sm font-semibold hover:opacity-90 transition disabled:opacity-50 mt-2"
+            >
+              {loading
+                ? tab === "signin"
+                  ? "Signing in..."
+                  : "Creating account..."
+                : tab === "signin"
+                  ? "Sign in"
+                  : "Create account"}
+            </button>
+          </form>
+        </div>
       </div>
+
+      <p className="mt-6 text-xs text-brand-gray text-center max-w-sm">
+        Documents generated by this platform are AI-assisted drafts and should be
+        reviewed by a qualified attorney before use.
+      </p>
     </div>
   );
 }

--- a/frontend/src/app/nda/page.tsx
+++ b/frontend/src/app/nda/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { NdaFormData, defaultFormData } from "@/types/nda";
 import { ChatMessage, ChatNdaFields, emptyFields, sendChatMessage } from "@/lib/chatApi";
 import { useTemplateRenderer } from "@/hooks/useTemplateRenderer";
 import { DocumentPreview } from "@/components/preview/DocumentPreview";
 import { ChatPanel } from "@/components/chat/ChatPanel";
 import { SignatureModal } from "@/components/chat/SignatureModal";
+import { NavBar } from "@/components/NavBar";
+import { useAuth } from "@/lib/auth";
+import { DISCLAIMER } from "@/lib/disclaimer";
 
 function fieldsToFormData(fields: ChatNdaFields): NdaFormData {
   const today = new Date().toISOString().split("T")[0];
@@ -41,6 +43,7 @@ function fieldsToFormData(fields: ChatNdaFields): NdaFormData {
 }
 
 export default function NdaPage() {
+  const { user, loading: authLoading } = useAuth();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [currentFields, setCurrentFields] = useState<ChatNdaFields>(emptyFields);
   const [isLoading, setIsLoading] = useState(false);
@@ -50,7 +53,6 @@ export default function NdaPage() {
   const formData = useMemo(() => fieldsToFormData(currentFields), [currentFields]);
   const { coverpageHtml, termsHtml } = useTemplateRenderer(formData);
 
-  // Greet the user immediately on mount
   useEffect(() => {
     async function greet() {
       setIsLoading(true);
@@ -88,24 +90,33 @@ export default function NdaPage() {
     [messages, currentFields]
   );
 
+  if (authLoading || !user) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-brand-gray text-sm">Loading...</p>
+      </div>
+    );
+  }
+
   return (
     <div className="h-screen flex flex-col">
-      {/* Header */}
-      <header className="bg-brand-navy text-white px-6 py-3 flex items-center justify-between shrink-0">
-        <div>
-          <Link href="/" className="text-xs text-brand-gray hover:text-white mr-3">
-            ← Back
-          </Link>
-          <span className="font-semibold text-sm">Mutual NDA Creator</span>
-          <span className="text-brand-gray text-xs ml-2">· Common Paper Version 1.0</span>
-        </div>
-        <button
-          onClick={() => setShowModal(true)}
-          className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90"
-        >
-          Download PDF
-        </button>
-      </header>
+      <NavBar
+        title="Mutual NDA Creator"
+        backHref="/"
+        rightSlot={
+          <button
+            onClick={() => setShowModal(true)}
+            className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90"
+          >
+            Download PDF
+          </button>
+        }
+      />
+
+      {/* Disclaimer banner */}
+      <div className="bg-amber-50 border-b border-amber-200 px-6 py-1.5 text-xs text-amber-700 shrink-0">
+        {DISCLAIMER}
+      </div>
 
       {/* Main split pane */}
       <div className="flex flex-1 overflow-hidden">

--- a/frontend/src/app/nda/page.tsx
+++ b/frontend/src/app/nda/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { NdaFormData, defaultFormData } from "@/types/nda";
 import { ChatMessage, ChatNdaFields, emptyFields, sendChatMessage } from "@/lib/chatApi";
 import { useTemplateRenderer } from "@/hooks/useTemplateRenderer";
@@ -10,6 +11,7 @@ import { SignatureModal } from "@/components/chat/SignatureModal";
 import { NavBar } from "@/components/NavBar";
 import { useAuth } from "@/lib/auth";
 import { DISCLAIMER } from "@/lib/disclaimer";
+import { saveDocument, getDocument } from "@/lib/documentsApi";
 
 function fieldsToFormData(fields: ChatNdaFields): NdaFormData {
   const today = new Date().toISOString().split("T")[0];
@@ -42,31 +44,46 @@ function fieldsToFormData(fields: ChatNdaFields): NdaFormData {
   };
 }
 
-export default function NdaPage() {
+function NdaPageInner() {
   const { user, loading: authLoading } = useAuth();
+  const searchParams = useSearchParams();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [currentFields, setCurrentFields] = useState<ChatNdaFields>(emptyFields);
   const [isLoading, setIsLoading] = useState(false);
   const [chatError, setChatError] = useState<string | null>(null);
   const [showModal, setShowModal] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [mobileTab, setMobileTab] = useState<"chat" | "preview">("chat");
 
   const formData = useMemo(() => fieldsToFormData(currentFields), [currentFields]);
   const { coverpageHtml, termsHtml } = useTemplateRenderer(formData);
 
+  // Resume from saved document or greet on mount
   useEffect(() => {
-    async function greet() {
+    const resumeId = searchParams.get("resume");
+    if (resumeId) {
+      getDocument(Number(resumeId))
+        .then((doc) => {
+          setCurrentFields({ ...emptyFields, ...doc.fields } as ChatNdaFields);
+          setMessages([{ role: "assistant", content: "Welcome back! Your saved document has been loaded. Continue chatting to make changes." }]);
+        })
+        .catch(() => {
+          setChatError("Failed to load saved document. Starting fresh.");
+        });
+    } else {
       setIsLoading(true);
-      try {
-        const res = await sendChatMessage([], emptyFields);
-        setMessages([{ role: "assistant", content: res.reply }]);
-        setCurrentFields(res.fields);
-      } catch {
-        setChatError("Failed to connect to the AI. Please refresh and try again.");
-      } finally {
-        setIsLoading(false);
-      }
+      sendChatMessage([], emptyFields)
+        .then((res) => {
+          setMessages([{ role: "assistant", content: res.reply }]);
+          setCurrentFields(res.fields);
+        })
+        .catch(() => {
+          setChatError("Failed to connect to the AI. Please refresh and try again.");
+        })
+        .finally(() => setIsLoading(false));
     }
-    greet();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleSend = useCallback(
@@ -90,6 +107,19 @@ export default function NdaPage() {
     [messages, currentFields]
   );
 
+  function handleSave() {
+    const html = coverpageHtml + termsHtml;
+    const fields = currentFields as unknown as Record<string, string | null>;
+    setIsSaving(true);
+    saveDocument({ doc_type: "mutual-nda", title: "Mutual Non-Disclosure Agreement", fields, html })
+      .then(() => {
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
+      })
+      .catch(() => setChatError("Failed to save document."))
+      .finally(() => setIsSaving(false));
+  }
+
   if (authLoading || !user) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
@@ -104,12 +134,21 @@ export default function NdaPage() {
         title="Mutual NDA Creator"
         backHref="/"
         rightSlot={
-          <button
-            onClick={() => setShowModal(true)}
-            className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90"
-          >
-            Download PDF
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleSave}
+              disabled={isSaving}
+              className="bg-brand-blue text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90 disabled:opacity-50"
+            >
+              {saved ? "Saved" : isSaving ? "Saving..." : "Save"}
+            </button>
+            <button
+              onClick={() => setShowModal(true)}
+              className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90"
+            >
+              Download PDF
+            </button>
+          </div>
         }
       />
 
@@ -118,11 +157,27 @@ export default function NdaPage() {
         {DISCLAIMER}
       </div>
 
+      {/* Mobile tab toggle */}
+      <div className="flex md:hidden border-b border-gray-200 shrink-0">
+        <button
+          onClick={() => setMobileTab("chat")}
+          className={`flex-1 py-2 text-xs font-semibold text-center ${mobileTab === "chat" ? "text-brand-blue border-b-2 border-brand-blue" : "text-brand-gray"}`}
+        >
+          Chat
+        </button>
+        <button
+          onClick={() => setMobileTab("preview")}
+          className={`flex-1 py-2 text-xs font-semibold text-center ${mobileTab === "preview" ? "text-brand-blue border-b-2 border-brand-blue" : "text-brand-gray"}`}
+        >
+          Preview
+        </button>
+      </div>
+
       {/* Main split pane */}
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
         {/* Left: Chat */}
-        <div className="w-2/5 flex flex-col border-r border-gray-200 bg-white">
-          <div className="px-4 py-3 border-b border-gray-100 shrink-0">
+        <div className={`${mobileTab === "chat" ? "flex" : "hidden"} md:flex w-full md:w-2/5 flex-col border-r border-gray-200 bg-white flex-1 md:flex-initial`}>
+          <div className="px-4 py-3 border-b border-gray-100 shrink-0 hidden md:block">
             <p className="text-xs font-medium text-brand-navy">AI Assistant</p>
             <p className="text-xs text-brand-gray">Answers update the document preview live</p>
           </div>
@@ -138,12 +193,12 @@ export default function NdaPage() {
         </div>
 
         {/* Right: Document preview */}
-        <div className="flex-1 flex flex-col bg-gray-50 overflow-hidden">
-          <div className="px-6 py-3 border-b border-gray-200 shrink-0">
+        <div className={`${mobileTab === "preview" ? "flex" : "hidden"} md:flex flex-1 flex-col bg-gray-50 overflow-hidden`}>
+          <div className="px-6 py-3 border-b border-gray-200 shrink-0 hidden md:block">
             <p className="text-xs font-medium text-brand-navy">Document Preview</p>
             <p className="text-xs text-brand-gray">Updates as you chat</p>
           </div>
-          <div className="flex-1 overflow-auto p-6">
+          <div className="flex-1 overflow-auto p-4 md:p-6">
             <DocumentPreview coverpageHtml={coverpageHtml} termsHtml={termsHtml} />
           </div>
         </div>
@@ -153,5 +208,17 @@ export default function NdaPage() {
         <SignatureModal formData={formData} onClose={() => setShowModal(false)} />
       )}
     </div>
+  );
+}
+
+export default function NdaPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-brand-gray text-sm">Loading...</p>
+      </div>
+    }>
+      <NdaPageInner />
+    </Suspense>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -28,12 +28,21 @@ function getRoute(item: CatalogItem): string {
 export default function HomePage() {
   const { user, loading: authLoading } = useAuth();
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);
+  const [catalogError, setCatalogError] = useState(false);
+
+  function fetchCatalog() {
+    setCatalogError(false);
+    fetch(`${API_BASE}/api/catalog`)
+      .then((r) => {
+        if (!r.ok) throw new Error();
+        return r.json();
+      })
+      .then(setCatalog)
+      .catch(() => setCatalogError(true));
+  }
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/catalog`)
-      .then((r) => r.json())
-      .then(setCatalog)
-      .catch(() => {});
+    fetchCatalog();
   }, []);
 
   if (authLoading || !user) {
@@ -56,7 +65,17 @@ export default function HomePage() {
           Select a template to get started.
         </p>
 
-        {catalog.length === 0 ? (
+        {catalogError ? (
+          <div className="text-center py-12">
+            <p className="text-red-600 text-sm mb-3">Failed to load templates.</p>
+            <button
+              onClick={fetchCatalog}
+              className="bg-brand-blue text-white px-4 py-2 rounded-lg text-sm font-semibold hover:opacity-90"
+            >
+              Retry
+            </button>
+          </div>
+        ) : catalog.length === 0 ? (
           <p className="text-brand-gray">Loading templates...</p>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useAuth } from "@/lib/auth";
+import { NavBar } from "@/components/NavBar";
+import { MyDocuments } from "@/components/MyDocuments";
+import { DISCLAIMER } from "@/lib/disclaimer";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001";
 
@@ -11,19 +15,18 @@ interface CatalogItem {
   filename: string;
 }
 
-// Documents that use a special dedicated route
 const SPECIAL_ROUTES: Record<string, string> = {
   "Mutual Non-Disclosure Agreement": "/nda",
 };
 
 function getRoute(item: CatalogItem): string {
   if (SPECIAL_ROUTES[item.name]) return SPECIAL_ROUTES[item.name];
-  // Derive slug from template filename: "templates/CSA.md" → "csa"
   const slug = item.filename.replace("templates/", "").replace(".md", "").toLowerCase();
   return `/doc/${slug}`;
 }
 
 export default function HomePage() {
+  const { user, loading: authLoading } = useAuth();
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);
 
   useEffect(() => {
@@ -33,19 +36,19 @@ export default function HomePage() {
       .catch(() => {});
   }, []);
 
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-brand-navy text-white py-4 px-8 flex items-center justify-between">
-        <span className="text-xl font-bold tracking-tight">Prelegal</span>
-        <Link
-          href="/login"
-          className="text-sm text-brand-gray hover:text-white transition-colors"
-        >
-          Sign out
-        </Link>
-      </header>
+  if (authLoading || !user) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <p className="text-brand-gray text-sm">Loading...</p>
+      </div>
+    );
+  }
 
-      <main className="max-w-5xl mx-auto px-6 py-12">
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <NavBar />
+
+      <main className="flex-1 max-w-5xl mx-auto px-6 py-12 w-full">
         <h1 className="text-3xl font-bold text-brand-navy mb-2">
           Document Templates
         </h1>
@@ -79,7 +82,15 @@ export default function HomePage() {
             })}
           </div>
         )}
+
+        <MyDocuments />
       </main>
+
+      <footer className="max-w-5xl mx-auto px-6 pb-8 w-full">
+        <p className="text-xs text-brand-gray text-center border-t border-gray-200 pt-6">
+          {DISCLAIMER}
+        </p>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/components/MyDocuments.tsx
+++ b/frontend/src/components/MyDocuments.tsx
@@ -1,19 +1,34 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { DocumentRecord, getDocuments } from "@/lib/documentsApi";
 import { printDocument } from "@/lib/printDocument";
 
+function resumeHref(doc: DocumentRecord): string {
+  if (doc.doc_type === "mutual-nda") return `/nda?resume=${doc.id}`;
+  return `/doc/${doc.doc_type}?resume=${doc.id}`;
+}
+
 export function MyDocuments() {
+  const router = useRouter();
   const [docs, setDocs] = useState<DocumentRecord[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [previewDoc, setPreviewDoc] = useState<DocumentRecord | null>(null);
 
-  useEffect(() => {
+  function fetchDocs() {
+    setLoading(true);
+    setError(false);
     getDocuments()
       .then(setDocs)
-      .catch(() => {})
+      .catch(() => setError(true))
       .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    fetchDocs();
   }, []);
 
   if (loading) {
@@ -22,7 +37,23 @@ export function MyDocuments() {
     );
   }
 
+  if (error) {
+    return (
+      <section className="mt-12">
+        <h2 className="text-xl font-bold text-brand-navy mb-4">My Documents</h2>
+        <p className="text-red-600 text-sm">
+          Failed to load documents.{" "}
+          <button onClick={fetchDocs} className="text-brand-blue underline hover:opacity-80">
+            Retry
+          </button>
+        </p>
+      </section>
+    );
+  }
+
   if (docs.length === 0) return null;
+
+  const displayed = docs.slice(0, 3);
 
   function formatDate(iso: string) {
     try {
@@ -40,9 +71,17 @@ export function MyDocuments() {
 
   return (
     <section className="mt-12">
-      <h2 className="text-xl font-bold text-brand-navy mb-4">My Documents</h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-bold text-brand-navy">My Documents</h2>
+        <Link
+          href="/documents"
+          className="text-xs font-medium text-brand-blue hover:underline"
+        >
+          View all →
+        </Link>
+      </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {docs.map((doc) => (
+        {displayed.map((doc) => (
           <button
             key={doc.id}
             onClick={() => setPreviewDoc(doc)}
@@ -52,7 +91,7 @@ export function MyDocuments() {
               {doc.title}
             </h3>
             <p className="text-xs text-brand-gray">
-              {formatDate(doc.created_at)}
+              {formatDate(doc.updated_at)}
             </p>
           </button>
         ))}
@@ -66,6 +105,15 @@ export function MyDocuments() {
                 {previewDoc.title}
               </h3>
               <div className="flex items-center gap-3">
+                <button
+                  onClick={() => {
+                    router.push(resumeHref(previewDoc));
+                    setPreviewDoc(null);
+                  }}
+                  className="bg-brand-blue text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90"
+                >
+                  Continue Editing
+                </button>
                 <button
                   onClick={() => printDocument(previewDoc.html)}
                   className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90"

--- a/frontend/src/components/MyDocuments.tsx
+++ b/frontend/src/components/MyDocuments.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { DocumentRecord, getDocuments } from "@/lib/documentsApi";
+import { printDocument } from "@/lib/printDocument";
+
+export function MyDocuments() {
+  const [docs, setDocs] = useState<DocumentRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [previewDoc, setPreviewDoc] = useState<DocumentRecord | null>(null);
+
+  useEffect(() => {
+    getDocuments()
+      .then(setDocs)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <p className="text-brand-gray text-sm mt-8">Loading your documents...</p>
+    );
+  }
+
+  if (docs.length === 0) return null;
+
+  function formatDate(iso: string) {
+    try {
+      return new Date(iso).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      });
+    } catch {
+      return iso;
+    }
+  }
+
+  return (
+    <section className="mt-12">
+      <h2 className="text-xl font-bold text-brand-navy mb-4">My Documents</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {docs.map((doc) => (
+          <button
+            key={doc.id}
+            onClick={() => setPreviewDoc(doc)}
+            className="text-left bg-white rounded-lg border border-gray-200 p-5 hover:border-brand-blue hover:shadow-md transition"
+          >
+            <h3 className="font-semibold text-brand-navy mb-1 text-sm">
+              {doc.title}
+            </h3>
+            <p className="text-xs text-brand-gray">
+              {formatDate(doc.created_at)}
+            </p>
+          </button>
+        ))}
+      </div>
+
+      {previewDoc && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-4xl max-h-[90vh] flex flex-col">
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+              <h3 className="font-semibold text-brand-navy">
+                {previewDoc.title}
+              </h3>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => printDocument(previewDoc.html)}
+                  className="bg-brand-purple text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:opacity-90"
+                >
+                  Download PDF
+                </button>
+                <button
+                  onClick={() => setPreviewDoc(null)}
+                  className="text-brand-gray hover:text-brand-navy text-sm"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+            <div className="flex-1 overflow-auto p-6">
+              <div
+                className="doc-content"
+                dangerouslySetInnerHTML={{ __html: previewDoc.html }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth, signout } from "@/lib/auth";
@@ -13,6 +14,7 @@ interface NavBarProps {
 export function NavBar({ title, backHref, rightSlot }: NavBarProps) {
   const router = useRouter();
   const { user } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   async function handleSignout() {
     await signout();
@@ -20,25 +22,26 @@ export function NavBar({ title, backHref, rightSlot }: NavBarProps) {
   }
 
   return (
-    <header className="bg-brand-navy text-white px-6 py-3 flex items-center justify-between shrink-0">
-      <div className="flex items-center gap-3">
+    <header className="bg-brand-navy text-white px-4 md:px-6 py-3 flex items-center justify-between shrink-0 relative">
+      <div className="flex items-center gap-2 md:gap-3 min-w-0">
         {backHref && (
-          <Link href={backHref} className="text-xs text-brand-gray hover:text-white">
+          <Link href={backHref} className="text-xs text-brand-gray hover:text-white shrink-0">
             ← Back
           </Link>
         )}
-        <Link href="/" className="font-semibold text-sm tracking-tight">
+        <Link href="/" className="font-semibold text-sm tracking-tight shrink-0">
           Prelegal
         </Link>
         {title && (
           <>
-            <span className="text-brand-gray text-xs">/</span>
-            <span className="text-sm">{title}</span>
+            <span className="text-brand-gray text-xs hidden sm:inline">/</span>
+            <span className="text-sm truncate hidden sm:inline">{title}</span>
           </>
         )}
       </div>
 
-      <div className="flex items-center gap-4">
+      {/* Desktop actions */}
+      <div className="hidden md:flex items-center gap-4">
         {rightSlot}
         {user && (
           <div className="flex items-center gap-3">
@@ -52,6 +55,39 @@ export function NavBar({ title, backHref, rightSlot }: NavBarProps) {
           </div>
         )}
       </div>
+
+      {/* Mobile hamburger */}
+      <button
+        onClick={() => setMenuOpen(!menuOpen)}
+        className="md:hidden text-white p-1"
+        aria-label="Toggle menu"
+      >
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+          {menuOpen ? (
+            <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+          ) : (
+            <path fillRule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clipRule="evenodd" />
+          )}
+        </svg>
+      </button>
+
+      {/* Mobile dropdown */}
+      {menuOpen && (
+        <div className="absolute top-full left-0 right-0 bg-brand-navy border-t border-white/10 p-4 flex flex-col gap-3 md:hidden z-50">
+          {rightSlot && <div className="flex items-center gap-2" onClick={() => setMenuOpen(false)}>{rightSlot}</div>}
+          {user && (
+            <>
+              <span className="text-xs text-brand-gray">{user.email}</span>
+              <button
+                onClick={handleSignout}
+                className="text-xs text-brand-gray hover:text-white transition-colors text-left"
+              >
+                Sign out
+              </button>
+            </>
+          )}
+        </div>
+      )}
     </header>
   );
 }

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAuth, signout } from "@/lib/auth";
+
+interface NavBarProps {
+  title?: string;
+  backHref?: string;
+  rightSlot?: React.ReactNode;
+}
+
+export function NavBar({ title, backHref, rightSlot }: NavBarProps) {
+  const router = useRouter();
+  const { user } = useAuth();
+
+  async function handleSignout() {
+    await signout();
+    router.push("/login");
+  }
+
+  return (
+    <header className="bg-brand-navy text-white px-6 py-3 flex items-center justify-between shrink-0">
+      <div className="flex items-center gap-3">
+        {backHref && (
+          <Link href={backHref} className="text-xs text-brand-gray hover:text-white">
+            ← Back
+          </Link>
+        )}
+        <Link href="/" className="font-semibold text-sm tracking-tight">
+          Prelegal
+        </Link>
+        {title && (
+          <>
+            <span className="text-brand-gray text-xs">/</span>
+            <span className="text-sm">{title}</span>
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-4">
+        {rightSlot}
+        {user && (
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-brand-gray">{user.email}</span>
+            <button
+              onClick={handleSignout}
+              className="text-xs text-brand-gray hover:text-white transition-colors"
+            >
+              Sign out
+            </button>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/chat/SignatureModal.tsx
+++ b/frontend/src/components/chat/SignatureModal.tsx
@@ -42,7 +42,7 @@ export function SignatureModal({ formData, onClose }: SignatureModalProps) {
         fields: formData as unknown as Record<string, string | null>,
         html,
       }).catch(() => {});
-      printDocument(html);
+      await printDocument(html);
       onClose();
     } catch (err) {
       setGenerateError(err instanceof Error ? err.message : "Failed to generate PDF");

--- a/frontend/src/components/chat/SignatureModal.tsx
+++ b/frontend/src/components/chat/SignatureModal.tsx
@@ -5,6 +5,7 @@ import { SignaturePad } from "@/components/signature/SignaturePad";
 import { NdaFormData } from "@/types/nda";
 import { generateNda } from "@/lib/apiClient";
 import { printDocument } from "@/lib/printDocument";
+import { saveDocument } from "@/lib/documentsApi";
 
 interface SignatureModalProps {
   formData: NdaFormData;
@@ -35,6 +36,12 @@ export function SignatureModal({ formData, onClose }: SignatureModalProps) {
         party2: { ...formData.party2, signature: sig2, date: today },
       };
       const { html } = await generateNda(data);
+      saveDocument({
+        doc_type: "mutual-nda",
+        title: "Mutual Non-Disclosure Agreement",
+        fields: formData as unknown as Record<string, string | null>,
+        html,
+      }).catch(() => {});
       printDocument(html);
       onClose();
     } catch (err) {

--- a/frontend/src/components/signature/SignaturePad.tsx
+++ b/frontend/src/components/signature/SignaturePad.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import ReactSignatureCanvas from "react-signature-canvas";
 
 interface SignaturePadProps {
@@ -12,6 +12,19 @@ interface SignaturePadProps {
 
 export function SignaturePad({ label, value, onChange, error }: SignaturePadProps) {
   const sigRef = useRef<ReactSignatureCanvas>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [canvasWidth, setCanvasWidth] = useState(400);
+
+  useEffect(() => {
+    function updateWidth() {
+      if (containerRef.current) {
+        setCanvasWidth(Math.min(containerRef.current.clientWidth - 4, 400));
+      }
+    }
+    updateWidth();
+    window.addEventListener("resize", updateWidth);
+    return () => window.removeEventListener("resize", updateWidth);
+  }, []);
 
   function handleEnd() {
     if (sigRef.current) {
@@ -32,15 +45,12 @@ export function SignaturePad({ label, value, onChange, error }: SignaturePadProp
       <label className="text-sm font-medium text-gray-700">
         {label} <span className="text-red-500">*</span>
       </label>
-      {/* Fixed-width container — matches the canvas pixel dimensions exactly to
-          prevent the CSS width / backing-buffer size mismatch that corrupts
-          the captured signature data URL. */}
-      <div className="border-2 border-dashed border-gray-300 rounded-md bg-gray-50 overflow-auto">
+      <div ref={containerRef} className="border-2 border-dashed border-gray-300 rounded-md bg-gray-50">
         <ReactSignatureCanvas
           ref={sigRef}
           penColor="black"
           canvasProps={{
-            width: 400,
+            width: canvasWidth,
             height: 150,
             style: { display: "block", touchAction: "none" },
           }}
@@ -56,7 +66,7 @@ export function SignaturePad({ label, value, onChange, error }: SignaturePadProp
           Clear
         </button>
         {value && (
-          <span className="text-xs text-green-600">✓ Signature captured</span>
+          <span className="text-xs text-green-600">Signature captured</span>
         )}
       </div>
       {error && <p className="text-xs text-red-500">{error}</p>}

--- a/frontend/src/lib/__tests__/printDocument.test.ts
+++ b/frontend/src/lib/__tests__/printDocument.test.ts
@@ -3,90 +3,70 @@ import { printDocument } from "@/lib/printDocument";
 
 describe("printDocument", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.clearAllMocks();
+    global.URL.createObjectURL = vi.fn(() => "blob:test-url");
+    global.URL.revokeObjectURL = vi.fn();
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("primary path: calls print via onload handler", () => {
-    const mockPrint = vi.fn();
-    const mockFocus = vi.fn();
-    const mockWrite = vi.fn();
-    const mockClose = vi.fn();
-    const mockWindow = {
-      print: mockPrint,
-      focus: mockFocus,
-      closed: false,
-      onload: null as (() => void) | null,
-      document: { write: mockWrite, close: mockClose },
-    };
-    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
+  it("sends HTML to backend and triggers PDF download", async () => {
+    const mockBlob = new Blob(["pdf-content"], { type: "application/pdf" });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(mockBlob),
+    });
 
-    printDocument("<p>test</p>");
+    const clickSpy = vi.fn();
+    vi.spyOn(document, "createElement").mockReturnValue({
+      set href(_: string) {},
+      set download(_: string) {},
+      click: clickSpy,
+    } as unknown as HTMLElement);
+    vi.spyOn(document.body, "appendChild").mockImplementation((n) => n);
+    vi.spyOn(document.body, "removeChild").mockImplementation((n) => n);
 
-    // Manually invoke the onload handler (simulating the window load event)
-    mockWindow.onload!();
+    await printDocument("<h1>Test</h1>");
 
-    expect(mockPrint).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/pdf"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ html: "<h1>Test</h1>", filename: "document.pdf" }),
+      })
+    );
+    expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("fallback path: calls print via setTimeout when onload does not fire", () => {
-    const mockPrint = vi.fn();
-    const mockFocus = vi.fn();
-    const mockWrite = vi.fn();
-    const mockClose = vi.fn();
-    const mockWindow = {
-      print: mockPrint,
-      focus: mockFocus,
-      closed: false,
-      onload: null as (() => void) | null,
-      document: { write: mockWrite, close: mockClose },
-    };
-    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
+  it("uses custom filename", async () => {
+    const mockBlob = new Blob(["pdf"], { type: "application/pdf" });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(mockBlob),
+    });
+    vi.spyOn(document, "createElement").mockReturnValue({
+      set href(_: string) {},
+      set download(_: string) {},
+      click: vi.fn(),
+    } as unknown as HTMLElement);
+    vi.spyOn(document.body, "appendChild").mockImplementation((n) => n);
+    vi.spyOn(document.body, "removeChild").mockImplementation((n) => n);
 
-    printDocument("<p>test</p>");
+    await printDocument("<p>test</p>", "my-nda.pdf");
 
-    // Do NOT call onload — advance fake timers to trigger the setTimeout fallback
-    vi.advanceTimersByTime(500);
-
-    expect(mockPrint).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({ html: "<p>test</p>", filename: "my-nda.pdf" }),
+      })
+    );
   });
 
-  it("blocked popup: shows alert with 'pop-up' message", () => {
-    vi.spyOn(window, "open").mockReturnValue(null as unknown as Window);
-    const mockAlert = vi.spyOn(window, "alert").mockImplementation(() => {});
+  it("throws on backend error", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
 
-    printDocument("<p>test</p>");
-
-    expect(mockAlert).toHaveBeenCalledWith(expect.stringContaining("pop-up"));
-  });
-
-  it("no double-print guard: print called exactly twice when both onload and timer fire", () => {
-    const mockPrint = vi.fn();
-    const mockFocus = vi.fn();
-    const mockWrite = vi.fn();
-    const mockClose = vi.fn();
-    const mockWindow = {
-      print: mockPrint,
-      focus: mockFocus,
-      closed: false,
-      onload: null as (() => void) | null,
-      document: { write: mockWrite, close: mockClose },
-    };
-    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
-
-    printDocument("<p>test</p>");
-
-    // Invoke onload manually (first print call)
-    mockWindow.onload!();
-
-    // Advance timer to trigger fallback (second print call)
-    vi.advanceTimersByTime(500);
-
-    // Both paths run independently — documented behavior is exactly 2 calls
-    expect(mockPrint).toHaveBeenCalledTimes(2);
+    await expect(printDocument("<p>fail</p>")).rejects.toThrow("PDF generation failed");
   });
 });

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -41,6 +41,7 @@ export async function generateNda(data: NdaFormData): Promise<NdaGenerateRespons
   const response = await fetch(`${API_BASE}/api/generate`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify(toApiPayload(data)),
   });
 
@@ -53,7 +54,9 @@ export async function generateNda(data: NdaFormData): Promise<NdaGenerateRespons
 }
 
 export async function fetchTemplate(name: "coverpage" | "terms"): Promise<string> {
-  const response = await fetch(`${API_BASE}/api/templates/${name}`);
+  const response = await fetch(`${API_BASE}/api/templates/${name}`, {
+    credentials: "include",
+  });
   if (!response.ok) {
     throw new Error(`Failed to fetch template: ${name}`);
   }

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001";
+
+interface AuthUser {
+  email: string;
+}
+
+let _cachedUser: AuthUser | null | undefined = undefined;
+
+export function setAuthCache(user: AuthUser | null) {
+  _cachedUser = user;
+}
+
+export function useAuth() {
+  const router = useRouter();
+  const [user, setUser] = useState<AuthUser | null>(_cachedUser ?? null);
+  const [loading, setLoading] = useState(_cachedUser === undefined);
+
+  useEffect(() => {
+    if (_cachedUser !== undefined) {
+      if (!_cachedUser) router.push("/login");
+      return;
+    }
+    fetch(`${API_BASE}/api/auth/me`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        _cachedUser = data;
+        setUser(data);
+        if (!data) router.push("/login");
+      })
+      .catch(() => {
+        _cachedUser = null;
+        setUser(null);
+        router.push("/login");
+      })
+      .finally(() => setLoading(false));
+  }, [router]);
+
+  return { user, loading };
+}
+
+export async function signout() {
+  await fetch(`${API_BASE}/api/auth/signout`, {
+    method: "POST",
+    credentials: "include",
+  }).catch(() => {});
+  _cachedUser = undefined;
+}

--- a/frontend/src/lib/chatApi.ts
+++ b/frontend/src/lib/chatApi.ts
@@ -57,6 +57,7 @@ export async function sendChatMessage(
   const response = await fetch(`${API_BASE}/api/chat`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify({ messages, current_fields: currentFields }),
   });
 

--- a/frontend/src/lib/disclaimer.ts
+++ b/frontend/src/lib/disclaimer.ts
@@ -1,0 +1,2 @@
+export const DISCLAIMER =
+  "These documents are AI-generated drafts for reference only and do not constitute legal advice. All documents should be reviewed by a qualified attorney before use.";

--- a/frontend/src/lib/docChatApi.ts
+++ b/frontend/src/lib/docChatApi.ts
@@ -19,6 +19,7 @@ export async function sendDocChatMessage(
   const response = await fetch(`${API_BASE}/api/doc-chat`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify({
       doc_type: docType,
       messages,
@@ -35,7 +36,9 @@ export async function sendDocChatMessage(
 }
 
 export async function fetchDocTemplate(slug: string): Promise<string> {
-  const response = await fetch(`${API_BASE}/api/doc-templates/${slug}`);
+  const response = await fetch(`${API_BASE}/api/doc-templates/${slug}`, {
+    credentials: "include",
+  });
   if (!response.ok) {
     throw new Error(`Failed to fetch template: ${slug}`);
   }
@@ -50,6 +53,7 @@ export async function generateDoc(
   const response = await fetch(`${API_BASE}/api/generate-doc`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify({ doc_type: docType, fields, title }),
   });
 

--- a/frontend/src/lib/documentsApi.ts
+++ b/frontend/src/lib/documentsApi.ts
@@ -5,7 +5,18 @@ export interface DocumentRecord {
   doc_type: string;
   title: string;
   created_at: string;
+  updated_at: string;
   html: string;
+}
+
+export interface DocumentDetail {
+  id: number;
+  doc_type: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+  html: string;
+  fields: Record<string, string | number | null>;
 }
 
 export async function saveDocument(payload: {
@@ -29,5 +40,13 @@ export async function getDocuments(): Promise<DocumentRecord[]> {
     credentials: "include",
   });
   if (!r.ok) throw new Error("Failed to fetch documents");
+  return r.json();
+}
+
+export async function getDocument(id: number): Promise<DocumentDetail> {
+  const r = await fetch(`${API_BASE}/api/documents/${id}`, {
+    credentials: "include",
+  });
+  if (!r.ok) throw new Error("Failed to fetch document");
   return r.json();
 }

--- a/frontend/src/lib/documentsApi.ts
+++ b/frontend/src/lib/documentsApi.ts
@@ -1,0 +1,33 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001";
+
+export interface DocumentRecord {
+  id: number;
+  doc_type: string;
+  title: string;
+  created_at: string;
+  html: string;
+}
+
+export async function saveDocument(payload: {
+  doc_type: string;
+  title: string;
+  fields: Record<string, string | null>;
+  html: string;
+}): Promise<{ id: number }> {
+  const r = await fetch(`${API_BASE}/api/documents`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+  if (!r.ok) throw new Error("Failed to save document");
+  return r.json();
+}
+
+export async function getDocuments(): Promise<DocumentRecord[]> {
+  const r = await fetch(`${API_BASE}/api/documents`, {
+    credentials: "include",
+  });
+  if (!r.ok) throw new Error("Failed to fetch documents");
+  return r.json();
+}

--- a/frontend/src/lib/printDocument.ts
+++ b/frontend/src/lib/printDocument.ts
@@ -1,26 +1,24 @@
-export function printDocument(html: string): void {
-  const printWindow = window.open("", "_blank", "width=900,height=700");
-  if (!printWindow) {
-    alert("Please allow pop-ups to download the PDF.");
-    return;
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8001";
+
+export async function printDocument(html: string, filename?: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/pdf`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ html, filename: filename ?? "document.pdf" }),
+  });
+
+  if (!res.ok) {
+    throw new Error("PDF generation failed");
   }
 
-  // Assign onload BEFORE document.write to avoid the race where the load
-  // event fires before the handler is attached.
-  printWindow.onload = () => {
-    printWindow.focus();
-    printWindow.print();
-  };
-
-  printWindow.document.write(html);
-  printWindow.document.close();
-
-  // Fallback: if onload already fired synchronously (common in Chrome),
-  // trigger print after a short delay.
-  setTimeout(() => {
-    if (printWindow && !printWindow.closed) {
-      printWindow.focus();
-      printWindow.print();
-    }
-  }, 500);
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename ?? "document.pdf";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
## Summary

- **Functional auth**: signup/signin with bcrypt password hashing, cookie-based session tokens, and route protection (redirect to /login if unauthenticated)
- **Document history**: documents saved to SQLite on PDF download; "My Documents" section on home page with preview modal and re-download capability
- **UI polish**: consistent NavBar across all pages (logo, user email, sign out), updated page metadata, fixed stale login API port
- **Disclaimer**: legal draft disclaimer on login page, home page footer, editor page banners, and embedded in generated PDFs

## Changes

### Backend (13 files)
- `database.py` — added `sessions` and `documents` tables, `get_db()` helper with `row_factory`
- `routers/auth.py` — replaced stubs with real signup/signin/signout/me routes using bcrypt + cookies
- `routers/documents.py` — new `POST /api/documents` and `GET /api/documents` endpoints
- `services/auth.py` — password hashing, session management, `require_session` FastAPI dependency
- `models/auth.py`, `models/documents.py` — Pydantic request/response models
- `services/doc_renderer.py`, `services/renderer.py` — disclaimer footer in generated HTML
- `main.py` — registered documents router
- `pyproject.toml` — added `bcrypt` and `pydantic[email]` dependencies
- `tests/test_auth.py` (9 tests), `tests/test_documents.py` (4 tests) — full coverage of new endpoints
- `tests/conftest.py` — `fresh_db` autouse fixture for test isolation

### Frontend (12 files)
- `lib/auth.ts` — module-level auth cache, `useAuth()` hook, `signout()`
- `lib/documentsApi.ts` — `saveDocument()` and `getDocuments()` API calls
- `lib/disclaimer.ts` — shared disclaimer text constant
- `components/NavBar.tsx` — consistent header with auth display and right slot pattern
- `components/MyDocuments.tsx` — document history grid with preview modal
- `app/login/page.tsx` — tabbed signin/signup, real API calls, error handling, fixed port bug
- `app/page.tsx` — auth guard, NavBar, MyDocuments section, disclaimer footer
- `app/nda/page.tsx`, `app/doc/[slug]/DocChatClient.tsx` — auth guard, NavBar, disclaimer banner, save-on-download
- `components/chat/SignatureModal.tsx` — fire-and-forget document save on NDA download
- `chatApi.ts`, `docChatApi.ts`, `apiClient.ts` — added `credentials: "include"` for cookie auth

## Test plan

- [ ] Sign up with a new email — verify session cookie set and redirect to home
- [ ] Sign out and sign back in — verify credentials work
- [ ] Try duplicate email signup — verify 409 error shown
- [ ] Access home page without auth — verify redirect to /login
- [ ] Create a document via AI chat and download PDF — verify disclaimer in PDF
- [ ] Check home page shows the document in "My Documents" section
- [ ] Click a saved document — verify preview modal with re-download
- [ ] Verify NavBar shows user email and sign out across all pages
- [ ] Backend: `uv run pytest tests/` — 76 tests pass
- [ ] Frontend: `npm run build` — compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)